### PR TITLE
add batched fields for better GPU usage

### DIFF
--- a/src/CMBLensing.jl
+++ b/src/CMBLensing.jl
@@ -106,11 +106,11 @@ include("flat_generic.jl")
 # include("taylens.jl")
 # include("bilinearlens.jl")
 # 
-# # plotting
-# isjuno = false
-# function animate end
-# @init @require Juno="e5e0dc1b-0480-54bc-9374-aad01c23163d" isjuno=Juno.isactive()
-# @init @require PyPlot="d330b81b-6aea-500a-939a-2ce795aea3ee" include("plotting.jl")
+# plotting
+isjuno = false
+function animate end
+@init @require Juno="e5e0dc1b-0480-54bc-9374-aad01c23163d" isjuno=Juno.isactive()
+@init @require PyPlot="d330b81b-6aea-500a-939a-2ce795aea3ee" include("plotting.jl")
 # 
 # # sampling and maximizing the posteriors
 # include("dataset.jl")

--- a/src/CMBLensing.jl
+++ b/src/CMBLensing.jl
@@ -60,26 +60,26 @@ import Measurements: ±
 import Statistics: std
 
 
-export 
+export  
     @BandpowerParamOp, @ismain, @namedtuple, @repeated, @unpack, animate,
-    argmaxf_lnP, BandPassOp, cache, CachedLenseFlow, camb, cov_to_Cℓ, cpu, Cℓ_2D,
-    Cℓ_to_Cov, DataSet, DerivBasis, diag, Diagonal, DiagOp, dot, EBFourier, EBMap,
-    Field, FieldArray, fieldinfo, FieldMatrix, FieldOrOpArray, FieldOrOpMatrix,
-    FieldOrOpRowVector, FieldOrOpVector, FieldRowVector, FieldTuple, FieldVector,
-    FieldVector, firsthalf, Flat, FlatEB, FlatEBFourier, FlatEBMap, FlatField,
-    FlatFieldFourier, FlatFieldMap, FlatFourier, FlatIEBCov, FlatIEBFourier,
-    FlatIEBMap, FlatIQUFourier, FlatIQUMap, FlatMap, FlatQU, FlatQUFourier,
-    FlatQUMap, FlatS0, FlatS02, FlatS2, FlatS2Fourier, FlatS2Map, Fourier, fourier∂,
-    FuncOp, get_Cℓ, get_Cℓ, get_Dℓ, get_αℓⁿCℓ, get_ρℓ, get_ℓ⁴Cℓ, gradhess, HighPass,
-    Identity, IdentityOp, IEBFourier, IEBMap, InterpolatedCℓs, IQUFourier, IQUMap,
-    lasthalf, LazyBinaryOp, LenseBasis, LenseFlow, LinOp, lnP, load_camb_Cℓs,
-    load_chains, load_sim_dataset, LowPass, make_mask, Map, MAP_joint, MAP_marg,
-    map∂, MidPass, mix, nan2zero, noiseCℓs, OuterProdOp, ParamDependentOp, pixwin,
-    PowerLens, QUFourier, QUMap, resimulate!, resimulate, RK4Solver, S0, S02, S2,
-    sample_joint, seed_for_storage!, shiftℓ, simulate, SymmetricFuncOp,
-    symplectic_integrate, Taylens, toCℓ, toDℓ, tuple_adjoint, ud_grade, unmix, Ð, Ł,
-    δf̃ϕ_δfϕ, δfϕ_δf̃ϕ, ℓ², ℓ⁴, ∇, ∇², ∇¹, ∇ᵢ, ∇⁰, ∇ⁱ, ∇₀, ∇₁, ⋅, ⨳
-
+    argmaxf_lnP, BandPassOp, batch, batchindex, batchsize, cache, CachedLenseFlow,
+    camb, cov_to_Cℓ, cpu, Cℓ_2D, Cℓ_to_Cov, DataSet, DerivBasis, diag, Diagonal,
+    DiagOp, dot, EBFourier, EBMap, Field, FieldArray, fieldinfo, FieldMatrix,
+    FieldOrOpArray, FieldOrOpMatrix, FieldOrOpRowVector, FieldOrOpVector,
+    FieldRowVector, FieldTuple, FieldVector, FieldVector, firsthalf, Flat, FlatEB,
+    FlatEBFourier, FlatEBMap, FlatField, FlatFieldFourier, FlatFieldMap,
+    FlatFourier, FlatIEBCov, FlatIEBFourier, FlatIEBMap, FlatIQUFourier, FlatIQUMap,
+    FlatMap, FlatQU, FlatQUFourier, FlatQUMap, FlatS0, FlatS02, FlatS2,
+    FlatS2Fourier, FlatS2Map, Fourier, fourier∂, FuncOp, get_Cℓ, get_Cℓ, get_Dℓ,
+    get_αℓⁿCℓ, get_ρℓ, get_ℓ⁴Cℓ, gradhess, HighPass, Identity, IdentityOp,
+    IEBFourier, IEBMap, InterpolatedCℓs, IQUFourier, IQUMap, lasthalf, LazyBinaryOp,
+    LenseBasis, LenseFlow, LinOp, lnP, load_camb_Cℓs, load_chains, load_sim_dataset,
+    LowPass, make_mask, Map, MAP_joint, MAP_marg, map∂, MidPass, mix, nan2zero,
+    noiseCℓs, OuterProdOp, ParamDependentOp, pixwin, PowerLens, QUFourier, QUMap,
+    resimulate!, resimulate, RK4Solver, S0, S02, S2, sample_joint,
+    seed_for_storage!, shiftℓ, simulate, SymmetricFuncOp, symplectic_integrate,
+    Taylens, toCℓ, toDℓ, tuple_adjoint, ud_grade, unbatch, unmix, Ð, Ł,
+    δfϕ_δf̃ϕ, ℓ², ℓ⁴, ∇, ∇², ∇¹, ∇ᵢ, ∇⁰, ∇ⁱ, ∇₀, ∇₁, ⋅, ⨳
 
 # generic stuff
 include("util.jl") 

--- a/src/CMBLensing.jl
+++ b/src/CMBLensing.jl
@@ -45,7 +45,7 @@ using Zygote: unbroadcast, Numeric, @adjoint
 
 
 import Adapt: adapt_structure
-import Base: +, -, *, \, /, ^, ~, ≈,
+import Base: +, -, *, \, /, ^, ~, ≈, <,
     abs, adjoint, axes, broadcast, broadcastable, BroadcastStyle, conj, convert,
     copy, copyto!, eltype, fill!, getindex, getproperty, hash, hcat, hvcat, inv,
     iterate, keys, lastindex, length, literal_pow, mapreduce, materialize!,
@@ -102,39 +102,41 @@ include("flat_s0.jl")
 include("flat_s2.jl")
 include("flat_s0s2.jl")
 include("flat_generic.jl")
-# include("masking.jl")
-# include("taylens.jl")
-# include("bilinearlens.jl")
-# 
+include("flat_batch.jl")
+include("masking.jl")
+include("taylens.jl")
+include("bilinearlens.jl")
+
 # plotting
 isjuno = false
 function animate end
 @init @require Juno="e5e0dc1b-0480-54bc-9374-aad01c23163d" isjuno=Juno.isactive()
 @init @require PyPlot="d330b81b-6aea-500a-939a-2ce795aea3ee" include("plotting.jl")
-# 
-# # sampling and maximizing the posteriors
-# include("dataset.jl")
-# include("posterior.jl")
-# include("maximization.jl")
-# include("sampling.jl")
-# include("chains.jl")
-# 
-# # other estimates
-# include("quadratic_estimate.jl")
-# 
-# # curved-sky
-# include("healpix.jl")
-# 
-# include("autodiff.jl")
-# 
-# # gpu
+
+# sampling and maximizing the posteriors
+include("dataset.jl")
+include("posterior.jl")
+include("maximization.jl")
+include("sampling.jl")
+include("chains.jl")
+
+# other estimates
+include("quadratic_estimate.jl")
+
+# curved-sky
+include("healpix.jl")
+
+include("autodiff.jl")
+
+# gpu
 is_gpu_backed(x) = false
 @init @require CuArrays="3a865a2d-5b23-5a0f-bc46-62713ec82fae" include("gpu.jl")
-# 
-# # misc init
-# # see https://github.com/timholy/ProgressMeter.jl/issues/71 and links therein
-# @init if ProgressMeter.@isdefined ijulia_behavior
-#     ProgressMeter.ijulia_behavior(:clear)
-# end
+
+# misc init
+# see https://github.com/timholy/ProgressMeter.jl/issues/71 and links therein
+@init if ProgressMeter.@isdefined ijulia_behavior
+    ProgressMeter.ijulia_behavior(:clear)
+end
 
 end
+ 

--- a/src/CMBLensing.jl
+++ b/src/CMBLensing.jl
@@ -128,8 +128,8 @@ function animate end
 # include("autodiff.jl")
 # 
 # # gpu
-# is_gpu_backed(x) = false
-# @init @require CuArrays="3a865a2d-5b23-5a0f-bc46-62713ec82fae" include("gpu.jl")
+is_gpu_backed(x) = false
+@init @require CuArrays="3a865a2d-5b23-5a0f-bc46-62713ec82fae" include("gpu.jl")
 # 
 # # misc init
 # # see https://github.com/timholy/ProgressMeter.jl/issues/71 and links therein

--- a/src/CMBLensing.jl
+++ b/src/CMBLensing.jl
@@ -102,39 +102,39 @@ include("flat_s0.jl")
 include("flat_s2.jl")
 include("flat_s0s2.jl")
 include("flat_generic.jl")
-include("masking.jl")
-include("taylens.jl")
-include("bilinearlens.jl")
-
-# plotting
-isjuno = false
-function animate end
-@init @require Juno="e5e0dc1b-0480-54bc-9374-aad01c23163d" isjuno=Juno.isactive()
-@init @require PyPlot="d330b81b-6aea-500a-939a-2ce795aea3ee" include("plotting.jl")
-
-# sampling and maximizing the posteriors
-include("dataset.jl")
-include("posterior.jl")
-include("maximization.jl")
-include("sampling.jl")
-include("chains.jl")
-
-# other estimates
-include("quadratic_estimate.jl")
-
-# curved-sky
-include("healpix.jl")
-
-include("autodiff.jl")
-
-# gpu
-is_gpu_backed(x) = false
-@init @require CuArrays="3a865a2d-5b23-5a0f-bc46-62713ec82fae" include("gpu.jl")
-
-# misc init
-# see https://github.com/timholy/ProgressMeter.jl/issues/71 and links therein
-@init if ProgressMeter.@isdefined ijulia_behavior
-    ProgressMeter.ijulia_behavior(:clear)
-end
+# include("masking.jl")
+# include("taylens.jl")
+# include("bilinearlens.jl")
+# 
+# # plotting
+# isjuno = false
+# function animate end
+# @init @require Juno="e5e0dc1b-0480-54bc-9374-aad01c23163d" isjuno=Juno.isactive()
+# @init @require PyPlot="d330b81b-6aea-500a-939a-2ce795aea3ee" include("plotting.jl")
+# 
+# # sampling and maximizing the posteriors
+# include("dataset.jl")
+# include("posterior.jl")
+# include("maximization.jl")
+# include("sampling.jl")
+# include("chains.jl")
+# 
+# # other estimates
+# include("quadratic_estimate.jl")
+# 
+# # curved-sky
+# include("healpix.jl")
+# 
+# include("autodiff.jl")
+# 
+# # gpu
+# is_gpu_backed(x) = false
+# @init @require CuArrays="3a865a2d-5b23-5a0f-bc46-62713ec82fae" include("gpu.jl")
+# 
+# # misc init
+# # see https://github.com/timholy/ProgressMeter.jl/issues/71 and links therein
+# @init if ProgressMeter.@isdefined ijulia_behavior
+#     ProgressMeter.ijulia_behavior(:clear)
+# end
 
 end

--- a/src/CMBLensing.jl
+++ b/src/CMBLensing.jl
@@ -16,7 +16,7 @@ using FFTW
 using InteractiveUtils
 using IterTools: flagfirst
 using JLD2: jldopen, JLDWriteSession
-using KahanSummation
+import KahanSummation
 using Loess
 using LinearAlgebra
 using LinearAlgebra: diagzero, matprod, promote_op

--- a/src/chains.jl
+++ b/src/chains.jl
@@ -135,6 +135,8 @@ function unbatch(chain::Chain)
             Dict(map(collect(samp)) do (k,v)
                 if v isa Union{BatchedReal,FlatField}
                     k => batchindex(v, I)
+                elseif v isa NamedTuple{<:Any, <:NTuple{<:Any,<:BatchedVals}}
+                    k => map(x -> (x isa BatchedReal ? batchindex(x,I) : x), v)
                 else
                     k => v
                 end

--- a/src/cls.jl
+++ b/src/cls.jl
@@ -124,7 +124,7 @@ end
     
     camb = @ondemand(PyCall.pyimport)(:camb)
     
-    Base.invokelatest(function ()
+    Base.invokelatest() do
     
         ℓmax′ = min(5000,ℓmax)
         cp = camb.set_params(
@@ -170,7 +170,7 @@ end
             params = (;params...)
         )
     
-    end)
+    end
 
 end
 

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -35,7 +35,7 @@ end
 
 function check_hat_operators(ds::DataSet)
     @unpack B̂, M̂, Cn̂, Cf = ds()
-    @assert(all([(L isa Scalar) || (L isa typeof(Cf)) || (Cf isa FlatIEBCov && L isa DiagOp{<:FlatIEBFourier}) for L in [B̂,M̂,Cn̂]]),
+    @assert(all([(L isa Scalar) || (basis(diag(L))==basis(diag(Cf))) || (Cf isa FlatIEBCov && L isa DiagOp{<:FlatIEBFourier}) for L in [B̂,M̂,Cn̂]]),
             "B̂, M̂, Cn̂ should be scalars or the same type as Cf")
 end
 

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -233,7 +233,7 @@ function load_sim_dataset(;
     if (G == nothing)
         Nϕ = quadratic_estimate(ds,(pol in (:P,:IP) ? :EB : :TT)).Nϕ / Nϕ_fac
         G₀ = @. nan2zero(sqrt(1 + 2/($Cϕ()/Nϕ)))
-        ds.G = ParamDependentOp((;Aϕ=Aϕ₀, _...)->(@. nan2zero(sqrt(1 + 2/(($Cϕ(;Aϕ=Aϕ)/Nϕ)))/G₀)))
+        ds.G = ParamDependentOp((;Aϕ=Aϕ₀, _...)->(pinv(G₀) * sqrt(I + 2 * Nϕ * pinv(Cϕ(Aϕ=Aϕ)))))
     end
     if (D == nothing)
         σ²len = T(deg2rad(5/60)^2)

--- a/src/field_tuples.jl
+++ b/src/field_tuples.jl
@@ -52,7 +52,6 @@ function similar(ft::FT, ::Type{T}, dims::Dims) where {T<:Number, B, FT<:FieldTu
     @assert size(ft)==dims "Tried to make a field similar to $FT but dims should have been $(size(f)), not $dims."
     FieldTuple{B}(map(f->similar(f,T),ft.fs))
 end
-# mapreduce(func, op, ft::FieldTuple; kw...) = mapreduce(f->mapreduce(func, op, f; kw...), op, ft.fs; kw...)
 function sum(f::FieldTuple; dims=:)
     if dims == (:)
         sum(sum,f.fs)
@@ -62,6 +61,7 @@ function sum(f::FieldTuple; dims=:)
         error("Invalid dims in sum(::FieldTuple, dims=$(dims)).")
     end
 end
+batchindex(f::FieldTuple{B,Names}, I) where {B,Names} = FieldTuple{B,Names}(map(f->batchindex(f, I), f.fs))
 
 ### broadcasting
 struct FieldTupleStyle{B,Names,FS<:Tuple} <: AbstractArrayStyle{1} end

--- a/src/field_tuples.jl
+++ b/src/field_tuples.jl
@@ -63,12 +63,16 @@ function sum(f::FieldTuple; dims=:)
 end
 
 ### broadcasting
-struct FieldTupleStyle{B,Names,FS<:Tuple} <: AbstractArrayStyle{1} end
+struct FieldTupleStyle{B,Names,FS} <: AbstractArrayStyle{1} end
 (::Type{FTS})(::Val{1}) where {FTS<:FieldTupleStyle} = FTS()
-BroadcastStyle(FS1::FieldTupleStyle{B1}, FS2::FieldTupleStyle{B2}) where {B1,B2} =
-    invalid_broadcast_error(B1,FS1,B2,FS2)
 BroadcastStyle(::Type{FT}) where {B,FS<:Tuple,FT<:FieldTuple{B,FS}} = FieldTupleStyle{B,Nothing,Tuple{map_tupleargs(typeof∘BroadcastStyle,FS)...}}()
 BroadcastStyle(::Type{FT}) where {B,Names,FS,NT<:NamedTuple{Names,FS},FT<:FieldTuple{B,NT}} = FieldTupleStyle{B,Names,Tuple{map_tupleargs(typeof∘BroadcastStyle,FS)...}}()
+BroadcastStyle(::FieldTupleStyle{B,Names,FS1}, ::FieldTupleStyle{B,Names,FS2}) where {B,Names,FS1,FS2} = begin
+    FS = Tuple{map_tupleargs((S1,S2)->typeof(Broadcast.result_style(S1(),S2())), FS1, FS2)...}
+    FieldTupleStyle{B,Names,FS}()
+end
+BroadcastStyle(S1::FieldTupleStyle{B1}, S2::FieldTupleStyle{B2}) where {B1,B2} =
+    invalid_broadcast_error(B1,S1,B2,S2)
 similar(::Broadcasted{FTS}, ::Type{T}) where {T, FTS<:FieldTupleStyle} = similar(FTS,T)
 similar(::Type{FieldTupleStyle{B,Nothing,FS}}, ::Type{T}) where {B,FS,T} = FieldTuple{B}(map_tupleargs(F->similar(F,T), FS))
 similar(::Type{FieldTupleStyle{B,Names,FS}}, ::Type{T}) where {B,Names,FS,T} = FieldTuple{B}(NamedTuple{Names}(map_tupleargs(F->similar(F,T), FS)))

--- a/src/field_tuples.jl
+++ b/src/field_tuples.jl
@@ -61,7 +61,6 @@ function sum(f::FieldTuple; dims=:)
         error("Invalid dims in sum(::FieldTuple, dims=$(dims)).")
     end
 end
-batchindex(f::FieldTuple{B,Names}, I) where {B,Names} = FieldTuple{B,Names}(map(f->batchindex(f, I), f.fs))
 
 ### broadcasting
 struct FieldTupleStyle{B,Names,FS<:Tuple} <: AbstractArrayStyle{1} end

--- a/src/flat_batch.jl
+++ b/src/flat_batch.jl
@@ -1,0 +1,85 @@
+# functions specific to creating "batched" fields, which are fields that
+# simultaneously store and operate on several maps at a time. this is mainly
+# useful on GPUs where operating on batches of fields is sometimes no slower
+# than a single field. 
+
+@doc doc"""
+    batch(fs::FlatField...)
+    batch(fs::Vector{<:FlatField})
+    batch(fs::TUple{<:FlatField})
+    
+Turn a length-N array of `FlatField`'s into a single batch-length-N `FlatField`.
+For the inverse operation, see [`unbatch`](@ref). 
+"""
+batch(fs::F...) where {N,θ,∂m,F<:FlatS0{<:Flat{N,θ,∂m}}} = 
+    basetype(F){Flat{N,θ,∂m,length(fs)}}(cat(map(firstfield,fs)..., dims=3))
+batch(fs::F...) where {F<:Union{FlatS2,FlatS02}} =
+    FieldTuple{basis(F)}(map(batch, map(firstfield,fs)...))
+batch(fs::Union{Vector{<:FlatField},Tuple{<:FlatField}}) = batch(fs...)
+
+@doc doc"""
+    batch(f::FlatField, D::Int)
+    
+Construct a batch-length-`D` `FlatField` from an unbatched `FlatField` which
+will broadcast as if it were `D` copies of `f` (without actually making `D`
+copies of the data in `f`)
+"""    
+batch(f::F, D::Int) where {N,θ,∂m,F<:FlatS0{Flat{N,θ,∂m,1}}} = basetype(F){Flat{N,θ,∂m,D}}(firstfield(f))
+batch(f::F, D::Int) where {F<:Union{FlatS2,FlatS02}} = FieldTuple{basis(F)}(map(f->batch(f,D), f.fs))
+batch(f::Field, ::Nothing) = f
+
+@doc doc"""
+    unbatch(f::FlatField)
+    
+If `f` is a batch-length-`D` field, return length-`D` vector of each batch
+component, otherwise just return `f`. For the inverse operation, see
+[`batch`](@ref).
+"""
+unbatch(f::FlatField{<:Flat{<:Any,<:Any,<:Any,1}}) = f
+unbatch(f::FlatField{<:Flat{<:Any,<:Any,<:Any,D}}) where {D} = [batchindex(f,i) for i=1:D]
+
+@doc """
+    batchindex(f::FlatField, I)
+    
+Get the `I`th indexed batch (`I` can be a slice). 
+"""
+batchindex(f::F, I) where {N,θ,∂mode,P<:Flat{N,θ,∂mode},F<:FlatS0{P}} = 
+    basetype(F){Flat{N,θ,∂mode,length(I)}}(f[:,:,I])
+batchindex(f::FlatField, I) = 
+    FieldTuple{basis(f)}(map(f->batchindex(f, I), f.fs))
+
+@doc """
+    batchlength(f::FlatField)
+    
+The number of batches of Fields in this object.
+"""
+batchsize(::FlatField{<:Flat{<:Any,<:Any,<:Any,D}}) where {D} = D
+
+@doc doc"""
+    BatchedReal(::Vector{<:Real}) <: Real
+
+Holds a vector of real numbers and broadcasts algebraic operations over them,
+as well as broadcasting with batched `FlatField`s, but is itself a `Real`. 
+"""
+struct BatchedReal{T<:Real,D,V<:AbstractVector{T}} <: Real
+    vals :: V
+    BatchedReal(v::V) where {T,V<:AbstractVector{T}} = new{T,length(v),V}(v)
+end
+batch(r::Real) = r
+batch(v::AbstractVector) = BatchedReal(v)
+for op in [:+, :-, :*, :/]
+    @eval begin
+        ($op)(a::BatchedReal, b::BatchedReal) = BatchedReal(broadcast(($op), a.vals, b.vals))
+        ($op)(a::BatchedReal, b::Real)        = BatchedReal(broadcast(($op), a.vals, b))
+        ($op)(a::Real, b::BatchedReal)        = BatchedReal(broadcast(($op), a,      b.vals))
+    end
+end
+<(a::BatchedReal, b::BatchedReal) = all(a.vals .< b.vals)
+<(a::BatchedReal, b::Real) = all(a.vals .< b)
+eltype(::BatchedReal{T}) where {T} = T
+broadcastable(::Type{<:FlatS0}, br::BatchedReal) = reshape(br.vals,1,1,length(br.vals))
+one(br::BatchedReal) = BatchedReal(one.(br.vals))
+unbatch(br::BatchedReal) = br.vals
+unbatch(r::Real) = r
+
+batch(L::Diagonal{<:Any,<:FlatField}, D::Int) = Diagonal(batch(diag(L), D))

--- a/src/flat_batch.jl
+++ b/src/flat_batch.jl
@@ -83,5 +83,7 @@ broadcastable(::Type{<:FlatS0}, br::BatchedReal) = reshape(br.vals,1,1,length(br
 one(br::BatchedReal) = BatchedReal(one.(br.vals))
 unbatch(br::BatchedReal) = br.vals
 unbatch(r::Real) = r
+Base.show(io::IO, br::BatchedReal{T}) where {T} = print(io, "Batched", T, br.vals)
+
 
 batch(L::Diagonal{<:Any,<:FlatField}, D::Int) = Diagonal(batch(diag(L), D))

--- a/src/flat_batch.jl
+++ b/src/flat_batch.jl
@@ -67,6 +67,7 @@ struct BatchedReal{T<:Real,D,V<:AbstractVector{T}} <: Real
 end
 batch(r::Real) = r
 batch(v::AbstractVector) = BatchedReal(v)
+batchindex(br::BatchedReal, I) = getindex(br.vals,I)
 for op in [:+, :-, :*, :/]
     @eval begin
         ($op)(a::BatchedReal, b::BatchedReal) = BatchedReal(broadcast(($op), a.vals, b.vals))

--- a/src/flat_batch.jl
+++ b/src/flat_batch.jl
@@ -76,6 +76,7 @@ for op in [:+, :-, :*, :/]
 end
 <(a::BatchedReal, b::BatchedReal) = all(a.vals .< b.vals)
 <(a::BatchedReal, b::Real) = all(a.vals .< b)
+sqrt(br::BatchedReal) = BatchedReal(sqrt.(br.vals))
 eltype(::BatchedReal{T}) where {T} = T
 broadcastable(::Type{<:FlatS0}, br::BatchedReal) = reshape(br.vals,1,1,length(br.vals))
 one(br::BatchedReal) = BatchedReal(one.(br.vals))

--- a/src/flat_fftgrid.jl
+++ b/src/flat_fftgrid.jl
@@ -9,10 +9,10 @@ promote_rule(::Type{map∂}, ::Type{fourier∂}) = fourier∂
 
 # Flat{Nside,θpix,∂mode} is a flat sky pixelization with `Nside` pixels per side
 # and pixels of width `θpix` arcmins, where derivatives are done according to ∂mode
-abstract type Flat{Nside,θpix,∂mode<:∂modes} <: Pix end
+abstract type Flat{Nside,θpix,∂mode<:∂modes,D} <: Pix end
 
 # for convenience
-Flat(;Nside, θpix=θpix₀, ∂mode=fourier∂) = Flat{Nside,θpix,∂mode}
+Flat(;Nside, θpix=θpix₀, ∂mode=fourier∂, D=1) = Flat{Nside,θpix,∂mode,D}
 Nside(::Type{P}) where {N,P<:Flat{N}} = N
 
 # default angular resolution used by a number of convenience constructors
@@ -32,12 +32,12 @@ const FFTW_NUM_THREADS = Ref{Int}()
 @init FFTW_NUM_THREADS[] = parse(Int,get(ENV,"FFTW_NUM_THREADS","$(Sys.CPU_THREADS÷2)"))
 
 
-@generated function FlatInfo(::Type{T}, ::Type{Arr}, ::Val{θpix}, ::Val{Nside}) where {T<:Real, Arr<:AbstractArray, θpix, Nside}
+@generated function FlatInfo(::Type{T}, ::Type{Arr}, ::Val{θpix}, ::Val{Nside}, ::Val{D}) where {T<:Real, Arr<:AbstractArray, θpix, Nside, D}
 
     FFTW.set_num_threads(FFTW_NUM_THREADS[])
 
     Δx   = T(deg2rad(θpix/60))
-    FFT  = plan_rfft(Arr{T}(undef,Nside,Nside))
+    FFT  = plan_rfft(Arr{T}(undef,Nside,Nside,D),(1,2))
     Δℓ   = T(2π/(Nside*Δx))
     nyq  = T(2π/(2Δx))
     Ωpix = T(Δx^2)

--- a/src/flat_fftgrid.jl
+++ b/src/flat_fftgrid.jl
@@ -37,7 +37,7 @@ const FFTW_NUM_THREADS = Ref{Int}()
     FFTW.set_num_threads(FFTW_NUM_THREADS[])
 
     Δx   = T(deg2rad(θpix/60))
-    FFT  = plan_rfft(Arr{T}(undef,Nside,Nside,D),(1,2))
+    FFT  = plan_rfft(Arr{T}(undef,Nside,Nside,(D==1 ? () : (D,))...), (1,2))
     Δℓ   = T(2π/(Nside*Δx))
     nyq  = T(2π/(2Δx))
     Ωpix = T(Δx^2)

--- a/src/flat_fftgrid.jl
+++ b/src/flat_fftgrid.jl
@@ -11,6 +11,9 @@ promote_rule(::Type{map∂}, ::Type{fourier∂}) = fourier∂
 # and pixels of width `θpix` arcmins, where derivatives are done according to ∂mode
 abstract type Flat{Nside,θpix,∂mode<:∂modes,D} <: Pix end
 
+# abstract type for the kind of data that can be stored in FlatFields
+const AbstractRank2or3Array{T} = Union{AbstractArray{T,2},AbstractArray{T,3}}
+
 # for convenience
 Flat(;Nside, θpix=θpix₀, ∂mode=fourier∂, D=1) = Flat{Nside,θpix,∂mode,D}
 Nside(::Type{P}) where {N,P<:Flat{N}} = N

--- a/src/flat_generic.jl
+++ b/src/flat_generic.jl
@@ -41,7 +41,7 @@ DerivBasis(::Type{<:FlatS0{<:Flat{<:Any,<:Any,map∂}}})      =    Map
 DerivBasis(::Type{<:FlatS2{<:Flat{<:Any,<:Any,map∂}}})      =  QUMap
 DerivBasis(::Type{<:FlatS02{<:Flat{<:Any,<:Any,map∂}}})     = IQUMap
 
-### construct batched fields
+### batching
 @doc doc"""
     batch(fs::FlatField...)
     batch(fs::Vector{<:FlatField})
@@ -63,6 +63,17 @@ will broadcast as if it were `D` copies of `f` (data not actually copied)
 """    
 batch(f::F, D::Int) where {N,θ,∂m,F<:FlatS0{Flat{N,θ,∂m,1}}} = basetype(F){Flat{N,θ,∂m,D}}(firstfield(f))
 batch(f::F, D::Int) where {F<:Union{FlatS2,FlatS02}} = FieldTuple{basis(F)}(map(f->batch(f,D), f.fs))
+
+@doc """
+    batchindex(f::FlatField, I)
+    
+Get the `I`th indexed batch (index can be a slice). 
+"""
+batchindex(f::F, I) where {N,θ,∂mode,P<:Flat{N,θ,∂mode},F<:FlatS0{P}} = 
+    basetype(F){Flat{N,θ,∂mode,length(I)}}(f[:,:,I])
+batchindex(f::FlatField, I) = 
+    FieldTuple{basis(B)}(map(f->batchindex(f, I), f.fs))
+
 
 ### derivatives
 

--- a/src/flat_generic.jl
+++ b/src/flat_generic.jl
@@ -72,7 +72,7 @@ Get the `I`th indexed batch (index can be a slice).
 batchindex(f::F, I) where {N,θ,∂mode,P<:Flat{N,θ,∂mode},F<:FlatS0{P}} = 
     basetype(F){Flat{N,θ,∂mode,length(I)}}(f[:,:,I])
 batchindex(f::FlatField, I) = 
-    FieldTuple{basis(B)}(map(f->batchindex(f, I), f.fs))
+    FieldTuple{basis(f)}(map(f->batchindex(f, I), f.fs))
 
 
 ### derivatives
@@ -127,13 +127,13 @@ broadcastable(::Type{F}, bp::BandPass) where {P,T,F<:FlatFourier{P,T}} = Cℓ_to
     
 
 ### logdets
-logdet(L::Diagonal{<:Complex,<:FlatFourier})   = real(sum_kbn(nan2zero.(log.(unfold(L.diag.Il)))))
-logdet(L::Diagonal{<:Real,<:FlatMap})          = real(sum_kbn(nan2zero.(log.(complex(L.diag.Ix)))))
-logdet(L::Diagonal{<:Complex,<:FlatEBFourier}) = real(sum_kbn(nan2zero.(log.(unfold(L.diag.El)))) + sum_kbn(nan2zero.(log.(unfold(L.diag.Bl)))))
+logdet(L::Diagonal{<:Complex,<:FlatFourier})   = real(sum_kbn(nan2zero.(log.(unfold(L.diag.Il))),dims=(1,2)))
+logdet(L::Diagonal{<:Real,<:FlatMap})          = real(sum_kbn(nan2zero.(log.(complex(L.diag.Ix))),dims=(1,2)))
+logdet(L::Diagonal{<:Complex,<:FlatEBFourier}) = real(sum_kbn(nan2zero.(log.(unfold(L.diag.El))),dims=(1,2)) + sum_kbn(nan2zero.(log.(unfold(L.diag.Bl))),dims=(1,2)))
 ### traces
-tr(L::Diagonal{<:Complex,<:FlatFourier})   = real(sum_kbn(unfold(L.diag.Il)))
-tr(L::Diagonal{<:Real,<:FlatMap})          = real(sum_kbn(complex(L.diag.Ix)))
-tr(L::Diagonal{<:Complex,<:FlatEBFourier}) = real(sum_kbn(unfold(L.diag.El)) + sum_kbn(unfold(L.diag.Bl)))
+tr(L::Diagonal{<:Complex,<:FlatFourier})   = real(sum_kbn(unfold(L.diag.Il),dims=(1,2)))
+tr(L::Diagonal{<:Real,<:FlatMap})          = real(sum_kbn(complex(L.diag.Ix),dims=(1,2)))
+tr(L::Diagonal{<:Complex,<:FlatEBFourier}) = real(sum_kbn(unfold(L.diag.El),dims=(1,2)) + sum_kbn(unfold(L.diag.Bl),dims=(1,2)))
 
 
 ### misc

--- a/src/flat_generic.jl
+++ b/src/flat_generic.jl
@@ -5,14 +5,14 @@ const FlatFieldFourier{P,T,M} = Union{FlatFourier{P,T,M},FlatS2{P,T,M},FlatS02Fo
 
 ### pretty printing
 @show_datatype show_datatype(io::IO, t::Type{F}) where {N,θ,∂mode,D,T,M,F<:FlatField{Flat{N,θ,∂mode,D},T,M}} =
-    print(io, "$(pretty_type_name(F)){$(N)×$(N) map, $(θ)′ pixels, $(∂mode.name.name), $M}")
+    print(io, "$(pretty_type_name(F)){$(N)×$(N)$(D==1 ? "" : "(×$D)") map, $(θ)′ pixels, $(∂mode.name.name), $M}")
 for F in (:FlatMap, :FlatFourier, 
           :FlatQUMap, :FlatQUFourier, :FlatEBMap, :FlatEBFourier, 
           :FlatIQUMap, :FlatIQUFourier, :FlatIEBMap, :FlatIEBFourier)
     @eval pretty_type_name(::Type{<:$F}) = $(string(F))
 end
 function Base.summary(io::IO, f::FlatField{<:Flat{N,<:Any,<:Any,D}}) where {N,D}
-    print(io, "$(N^2)", (D==1 ? "" : "(×$D batches)"), "-element ")
+    print(io, "$(N^2)", (D==1 ? "" : "(×$D)"), "-element ")
     showarg(io, f, true)
 end
 

--- a/src/flat_generic.jl
+++ b/src/flat_generic.jl
@@ -22,12 +22,12 @@ fieldinfo(::F) where {F<:FlatField} = fieldinfo(F)
 ### promotion & conversion
 # note: we don't need to promote the eltype T here since that will be
 # automatically handled in broadcasting
-function promote(f1::F1, f2::F2) where {T1,θ1,N1,∂mode1,F1<:FlatField{Flat{N1,θ1,∂mode1},T1},T2,θ2,N2,∂mode2,F2<:FlatField{Flat{θ2,N2,∂mode2},T2}}
+function promote(f1::F1, f2::F2) where {T1,θ1,N1,∂mode1,F1<:FlatField{<:Flat{N1,θ1,∂mode1},T1},T2,θ2,N2,∂mode2,F2<:FlatField{<:Flat{θ2,N2,∂mode2},T2}}
     B     = promote_type(basis(F1),basis(F2))
     ∂mode = promote_type(∂mode1,∂mode2)
     B(∂mode(f1)), B(∂mode(f2))
 end
-(::Type{∂mode})(f::F) where {∂mode<:∂modes,N,θ,F<:FlatS0{<:Flat{N,θ}}} = basetype(F){Flat{N,θ,∂mode}}(fieldvalues(f)...)
+(::Type{∂mode})(f::F) where {∂mode<:∂modes,N,θ,D,F<:FlatS0{<:Flat{N,θ,<:Any,D}}} = basetype(F){Flat{N,θ,∂mode,D}}(fieldvalues(f)...)
 (::Type{∂mode})(f::FieldTuple{B}) where {∂mode<:∂modes,B} = FieldTuple{B}(map(∂mode,f.fs))
 
 ### basis-like definitions

--- a/src/flat_generic.jl
+++ b/src/flat_generic.jl
@@ -4,8 +4,8 @@ const FlatFieldMap{P,T,M} = Union{FlatMap{P,T,M},FlatS2Map{P,T,M},FlatS02Map{P,T
 const FlatFieldFourier{P,T,M} = Union{FlatFourier{P,T,M},FlatS2{P,T,M},FlatS02Fourier{P,T,M}}
 
 ### pretty printing
-@show_datatype show_datatype(io::IO, t::Type{F}) where {N,θ,∂mode,T,M,F<:FlatField{Flat{N,θ,∂mode},T,M}} =
-    print(io, "$(pretty_type_name(F)){$(N)×$(N) map, $(θ)′ pixels, $(∂mode.name.name), $(M.name.name){$(M.parameters[1])}}")
+@show_datatype show_datatype(io::IO, t::Type{F}) where {N,θ,∂mode,D,T,M,F<:FlatField{Flat{N,θ,∂mode,D},T,M}} =
+    print(io, "$(pretty_type_name(F)){$(N)×$(N)$(D==1 ? "" : "×$D") map, $(θ)′ pixels, $(∂mode.name.name), $(M.name.name){$(M.parameters[1])}}")
 for F in (:FlatMap, :FlatFourier, 
           :FlatQUMap, :FlatQUFourier, :FlatEBMap, :FlatEBFourier, 
           :FlatIQUMap, :FlatIQUFourier, :FlatIEBMap, :FlatIEBFourier)
@@ -13,8 +13,8 @@ for F in (:FlatMap, :FlatFourier,
 end
 
 ### field info
-@generated fieldinfo(::Type{P},::Type{T}=Float32,::Type{M}=Matrix) where {Nside,θpix,∂mode,P<:Flat{Nside,θpix,∂mode},T,M} = 
-    (;FlatInfo(T,basetype(M),Val(θpix),Val(Nside))..., ∂mode=∂mode)
+@generated fieldinfo(::Type{P},::Type{T}=Float32,::Type{M}=Matrix) where {Nside,θpix,∂mode,D,P<:Flat{Nside,θpix,∂mode,D},T,M} = 
+    (;FlatInfo(T,basetype(M),Val(θpix),Val(Nside),Val(D))..., ∂mode=∂mode)
 @generated fieldinfo(::Type{F}) where {P<:Flat,T,M,F<:FlatField{P,T,M}} = 
     (;fieldinfo(P,T,M)..., @namedtuple(P,M,B=basis(F),S=spin(F))...)
 fieldinfo(::F) where {F<:FlatField} = fieldinfo(F)

--- a/src/flat_generic.jl
+++ b/src/flat_generic.jl
@@ -62,7 +62,8 @@ DerivBasis(::Type{<:FlatS02{<:Flat{<:Any,<:Any,map∂}}})     = IQUMap
     basetype(M)(@. $fieldinfo(F).k'^2 + $fieldinfo(F).k[1:N÷2+1]^2)
 
 ## Map-space
-function copyto!(f′::F, bc::Broadcasted{<:Any,<:Any,typeof(*),Tuple{∇diag{coord,covariant,prefactor},F}}) where {coord,covariant,prefactor,T,θ,N,F<:FlatMap{Flat{N,θ,map∂},T}}
+function copyto!(f′::F, bc::Broadcasted{<:Any,<:Any,typeof(*),Tuple{∇diag{coord,covariant,prefactor},F}}) where {coord,covariant,prefactor,T,θ,N,D,F<:FlatMap{Flat{N,θ,map∂,D},T}}
+    D!=1 && error("Gradients of batched map∂ flat maps not implemented yet.")
     f = bc.args[2]
     n,m = size(f.Ix)
     α = 2 * prefactor * fieldinfo(f).Δx

--- a/src/flat_s0.jl
+++ b/src/flat_s0.jl
@@ -49,8 +49,6 @@ function similar(f::F,::Type{T},dims::Dims) where {P,F<:FlatS0{P},T<:Number}
     @assert size(f)==dims "Tried to make a field similar to $F but dims should have been $(size(f)), not $dims."
     basetype(F){P}(similar(firstfield(f),T))
 end
-batchindex(f::F, I) where {N,θ,∂mode,P<:Flat{N,θ,∂mode},F<:FlatS0{P}} = 
-    basetype(F){Flat{N,θ,∂mode,length(I)}}(f[:,:,I])
 
 
 ### broadcasting

--- a/src/flat_s0.jl
+++ b/src/flat_s0.jl
@@ -49,6 +49,8 @@ function similar(f::F,::Type{T},dims::Dims) where {P,F<:FlatS0{P},T<:Number}
     @assert size(f)==dims "Tried to make a field similar to $F but dims should have been $(size(f)), not $dims."
     basetype(F){P}(similar(firstfield(f),T))
 end
+batchindex(f::F, I) where {N,θ,∂mode,P<:Flat{N,θ,∂mode},F<:FlatS0{P}} = 
+    basetype(F){Flat{N,θ,∂mode,length(I)}}(f[:,:,I])
 
 
 ### broadcasting

--- a/src/flat_s0.jl
+++ b/src/flat_s0.jl
@@ -101,7 +101,7 @@ end
 
 ### dot products
 # do in Map space for simplicity, and use sum_kbn to reduce roundoff error
-dot(a::FlatS0{P}, b::FlatS0{P}) where {P} = sum_kbn(Map(a).Ix .* Map(b).Ix)
+dot(a::FlatS0{P}, b::FlatS0{P}) where {P} = sum_kbn(Map(a).Ix .* Map(b).Ix, dims=(1,2))
 
 ### isapprox
 ≈(a::F, b::F) where {P,T,F<:FlatS0{P,T}} = all(.≈(a[:], b[:], atol=sqrt(eps(T)), rtol=sqrt(eps(T))))

--- a/src/flat_s0s2.jl
+++ b/src/flat_s0s2.jl
@@ -36,10 +36,14 @@ for (F,F2,F0,(X,Y,Z),(X′,Y′,Z′),T) in [
     """
     @eval begin
         @doc $doc $F
-        $F($X, $Y, $Z; kwargs...) = $F($F0($X; kwargs...), $F2($Y,$Z; kwargs...))
-        $F{P}($X, $Y, $Z) where {P} = $F{P}($F0{P}($X), $F2{P}($Y,$Z))
-        $F{P,T}($X, $Y, $Z) where {P,T} = $F{P,T}($F0{P,T}($X), $F2{P,T}($Y,$Z))
-        $F{P,T,M}($X, $Y, $Z) where {P,T,M} = $F{P,T,M}($F0{P,T,M}($X), $F2{P,T,M}($Y,$Z))
+        $F($X::AbstractRank2or3Array, $Y::AbstractRank2or3Array, $Z::AbstractRank2or3Array; kwargs...) =
+            $F($F0($X; kwargs...), $F2($Y,$Z; kwargs...))
+        $F{P}($X::AbstractRank2or3Array, $Y::AbstractRank2or3Array, $Z::AbstractRank2or3Array) where {P} =
+            $F{P}($F0{P}($X), $F2{P}($Y,$Z))
+        $F{P,T}($X::AbstractRank2or3Array, $Y::AbstractRank2or3Array, $Z::AbstractRank2or3Array) where {P,T} =
+            $F{P,T}($F0{P,T}($X), $F2{P,T}($Y,$Z))
+        $F{P,T,M}($X::AbstractRank2or3Array, $Y::AbstractRank2or3Array, $Z::AbstractRank2or3Array) where {P,T,M} =
+            $F{P,T,M}($F0{P,T,M}($X), $F2{P,T,M}($Y,$Z))
         $F($X′::$F0, $Y′::$F0, $Z′::$F0) = $F($X′, $F2($Y′,$Z′))
     end
 end

--- a/src/flat_s2.jl
+++ b/src/flat_s2.jl
@@ -21,22 +21,26 @@ for (F,F0,(X,Y),T) in [
     ]
     doc = """
         # main constructor:
-        $F($X::AbstractArray, $Y::AbstractArray[, θpix={resolution in arcmin}, ∂mode={fourier∂ or map∂})
+        $F($X::AbstractRank2or3Array, $Y::AbstractRank2or3Array[, θpix={resolution in arcmin}, ∂mode={fourier∂ or map∂})
         
         # more low-level:
-        $F{P}($X::AbstractArray, $Y::AbstractArray) # specify pixelization P explicilty
-        $F{P,T}($X::AbstractArray, $Y::AbstractArray) # additionally, convert elements to type $T
-        $F{P,T,M<:AbstractArray{$T}}($X::M, $Y::M) # specify everything explicilty
+        $F{P}($X::AbstractRank2or3Array, $Y::AbstractRank2or3Array) # specify pixelization P explicilty
+        $F{P,T}($X::AbstractRank2or3Array, $Y::AbstractRank2or3Array) # additionally, convert elements to type $T
+        $F{P,T,M<:AbstractRank2or3Array{$T}}($X::M, $Y::M) # specify everything explicilty
         
     Construct a `$F` object. The top form of the constructor is most convenient
     for interactive work, while the others may be more useful for low-level code.
     """
     @eval begin
         @doc $doc $F
-        $F($X::AbstractArray, $Y::AbstractArray; kwargs...) = $F{Flat(Nside=size($X,2),D=size($X,3);kwargs...)}($X, $Y)
-        $F{P}($X::AbstractArray, $Y::AbstractArray) where {P} = $F{P}(($F0{P}($X), $F0{P}($Y)))
-        $F{P,T}($X::AbstractArray, $Y::AbstractArray) where {P,T} = $F{P,T}($F0{P,T}($X), $F0{P,T}($Y))
-        $F{P,T,M}($X::AbstractArray, $Y::AbstractArray) where {P,T,M} = $F{P,T,M}($F0{P,T,M}($X), $F0{P,T,M}($Y))
+        $F($X::AbstractRank2or3Array, $Y::AbstractRank2or3Array; kwargs...) =
+            $F{Flat(Nside=size($X,2),D=size($X,3);kwargs...)}($X, $Y)
+        $F{P}($X::AbstractRank2or3Array, $Y::AbstractRank2or3Array) where {P} =
+            $F{P}(($F0{P}($X), $F0{P}($Y)))
+        $F{P,T}($X::AbstractRank2or3Array, $Y::AbstractRank2or3Array) where {P,T} =
+            $F{P,T}($F0{P,T}($X), $F0{P,T}($Y))
+        $F{P,T,M}($X::AbstractRank2or3Array, $Y::AbstractRank2or3Array) where {P,T,M} =
+            $F{P,T,M}($F0{P,T,M}($X), $F0{P,T,M}($Y))
     end
 end
 

--- a/src/flat_s2.jl
+++ b/src/flat_s2.jl
@@ -21,22 +21,22 @@ for (F,F0,(X,Y),T) in [
     ]
     doc = """
         # main constructor:
-        $F($X::AbstractMatrix, $Y::AbstractMatrix[, θpix={resolution in arcmin}, ∂mode={fourier∂ or map∂})
+        $F($X::AbstractArray, $Y::AbstractArray[, θpix={resolution in arcmin}, ∂mode={fourier∂ or map∂})
         
         # more low-level:
-        $F{P}($X::AbstractMatrix, $Y::AbstractMatrix) # specify pixelization P explicilty
-        $F{P,T}($X::AbstractMatrix, $Y::AbstractMatrix) # additionally, convert elements to type $T
-        $F{P,T,M<:AbstractMatrix{$T}}($X::M, $Y::M) # specify everything explicilty
+        $F{P}($X::AbstractArray, $Y::AbstractArray) # specify pixelization P explicilty
+        $F{P,T}($X::AbstractArray, $Y::AbstractArray) # additionally, convert elements to type $T
+        $F{P,T,M<:AbstractArray{$T}}($X::M, $Y::M) # specify everything explicilty
         
     Construct a `$F` object. The top form of the constructor is most convenient
     for interactive work, while the others may be more useful for low-level code.
     """
     @eval begin
         @doc $doc $F
-        $F($X::AbstractMatrix, $Y::AbstractMatrix; kwargs...) = $F{Flat(Nside=size($X,2);kwargs...)}($X, $Y)
-        $F{P}($X::AbstractMatrix, $Y::AbstractMatrix) where {P} = $F{P}($F0{P}($X), $F0{P}($Y))
-        $F{P,T}($X::AbstractMatrix, $Y::AbstractMatrix) where {P,T} = $F{P,T}($F0{P,T}($X), $F0{P,T}($Y))
-        $F{P,T,M}($X::AbstractMatrix, $Y::AbstractMatrix) where {P,T,M} = $F{P,T,M}($F0{P,T,M}($X), $F0{P,T,M}($Y))
+        $F($X::AbstractArray, $Y::AbstractArray; kwargs...) = $F{Flat(Nside=size($X,2),D=size($X,3);kwargs...)}($X, $Y)
+        $F{P}($X::AbstractArray, $Y::AbstractArray) where {P} = $F{P}(($F0{P}($X), $F0{P}($Y)))
+        $F{P,T}($X::AbstractArray, $Y::AbstractArray) where {P,T} = $F{P,T}($F0{P,T}($X), $F0{P,T}($Y))
+        $F{P,T,M}($X::AbstractArray, $Y::AbstractArray) where {P,T,M} = $F{P,T,M}($F0{P,T,M}($X), $F0{P,T,M}($Y))
     end
 end
 

--- a/src/generic.jl
+++ b/src/generic.jl
@@ -227,8 +227,8 @@ show_vector(io::IO, f::ImplicitField) = print(io, "[…]")
 
 # addition/subtraction works between any fields and scalars, promotion is done
 # automatically if fields are in different bases
-for op in (:+,:-), (T1,T2) in ((:Field,:Scalar),(:Scalar,:Field),(:Field,:Field))
-    @eval ($op)(a::$T1, b::$T2) = broadcast($op,($T1==$T2 ? promote : tuple)(a,b)...)
+for op in (:+,:-), (T1,T2,promote) in ((:Field,:Scalar,false),(:Scalar,:Field,false),(:Field,:Field,true))
+    @eval ($op)(a::$T1, b::$T2) = broadcast($op, ($promote ? promote(a,b) : (a,b))...)
 end
 
 ≈(a::Field, b::Field) = ≈(promote(a,b)...)

--- a/src/generic.jl
+++ b/src/generic.jl
@@ -246,7 +246,7 @@ end
 
 # misc
 one(f::Field) = fill!(similar(f), one(eltype(f)))
-norm(f::Field) = sqrt(dot(f,f)) # dot is implemented to add the factor of Δx
+norm(f::Field) = sqrt(dot(f,f))
 
 
 function invalid_broadcast_error(B1,F1,B2,F2)

--- a/src/gpu.jl
+++ b/src/gpu.jl
@@ -45,7 +45,7 @@ end
 pinv(D::Diagonal{T,<:CuFlatS0}) where {T} = Diagonal(@. ifelse(isfinite(inv(D.diag)), inv(D.diag), $zero(T)))
 inv(D::Diagonal{T,<:CuFlatS0}) where {T} = any(Array((D.diag.==0)[:])) ? throw(SingularException(-1)) : Diagonal(inv.(D.diag))
 fill!(f::CuFlatS0, x) = (fill!(firstfield(f),x); f)
-dot(a::CuFlatS0, b::CuFlatS0) = sum_kbn(Array(Map(a).Ix .* Map(b).Ix))
+dot(a::CuFlatS0, b::CuFlatS0) = dot(adapt(Array,Map(a)), adapt(Array,Map(b)))
 ≈(a::CuFlatS0, b::CuFlatS0) = (firstfield(a) ≈ firstfield(b))
 sum(f::CuFlatS0; dims=:) = (dims == :) ? sum(firstfield(f)) : error("Not implemented")
 

--- a/src/gpu.jl
+++ b/src/gpu.jl
@@ -22,7 +22,7 @@ seed_for_storage!(::Type{<:CuArray}, seed=nothing) =
 
 ### broadcasting
 preprocess(dest::F, bc::Broadcasted) where {F<:CuFlatS0} = 
-    Broadcasted{Nothing}(CuArrays.cufunc(bc.f), preprocess_args(dest, bc.args), map(OneTo,size_2d(F)))
+    Broadcasted{Nothing}(CuArrays.cufunc(bc.f), preprocess_args(dest, bc.args), map(OneTo,_size(F)))
 preprocess(dest::F, arg) where {M,F<:CuFlatS0{<:Any,<:Any,M}} = 
     adapt(M,broadcastable(F, arg))
 function copyto!(dest::F, bc::Broadcasted{Nothing}) where {F<:CuFlatS0}

--- a/src/maximization.jl
+++ b/src/maximization.jl
@@ -118,8 +118,8 @@ function MAP_joint(
     end
     
     # since MAP estimate is done at fixed θ, we don't need to reparametrize to
-    # ϕₘ = G(θ)*ϕ, so set G to constant here to avoid wasted computation
-    @set! ds.G = 1
+    # ϕ° = G(θ)*ϕ, so set G to constant here to avoid wasted computation
+    ds.G = 1
     @unpack d, D, Cϕ, Cf, Cf̃, Cn, Cn̂, L = ds
     
     f, f° = nothing, nothing

--- a/src/maximization.jl
+++ b/src/maximization.jl
@@ -25,14 +25,15 @@ argmaxf_lnP(ϕ::Field, θ::NamedTuple, ds::DataSet; kwargs...) = argmaxf_lnP(cac
 function argmaxf_lnP(Lϕ, ds::DataSet; which=:wf, guess=nothing, preconditioner=:diag, conjgrad_kwargs=())
     
     check_hat_operators(ds)
-    @unpack d, Cn, Cn̂, Cf, M, M̂, B, B̂, P = ds
+    @unpack d, Cn, Cn̂, Cf, M, M̂, B, B̂, P = ds()
+    D = batchsize(d)
     
     b = 0
     if (which in (:wf, :sample))
         b += Lϕ'*B'*P'*M'*(Cn\d)
     end
     if (which in (:fluctuation, :sample))
-        b += Cf\simulate(Cf) + Lϕ'*B'*P'*M'*(Cn\simulate(Cn))
+        b += Cf\simulate(batch(Cf,D)) + Lϕ'*B'*P'*M'*(Cn\simulate(batch(Cn,D)))
     end
     
     A_diag  = pinv(Cf) +     B̂' *  M̂'*pinv(Cn̂)*M̂ * B̂
@@ -122,8 +123,9 @@ function MAP_joint(
     @unpack d, D, Cϕ, Cf, Cf̃, Cn, Cn̂, L = ds
     
     f, f° = nothing, nothing
-    ϕ = (ϕstart==nothing) ? zero(diag(Cϕ)) : ϕstart
+    ϕ = (ϕstart==nothing) ? zero(identity.(batch(diag(Cϕ),batchsize(d)))) : ϕstart
     ϕstep = nothing
+    @show typeof(ϕ) typeof(d)
     Lϕ = cache(L(ϕ),d)
     T = real(eltype(d))
     α = 0

--- a/src/numerical_algorithms.jl
+++ b/src/numerical_algorithms.jl
@@ -116,9 +116,11 @@ function conjugate_gradient(M, A, b, x=0*b; nsteps=length(b), tol=sqrt(eps()), p
         # update progress bar to whichever we've made the most progress on,
         # logarithmically reaching the toleranace limit or doing the maximum
         # number of steps
-        progress_nsteps = round(Int,100*(i-1)/(nsteps-1))
-        progress_tol = round(Int,100^min(1, (log10(res/res₀)) / log10(tol/res₀)))
-        ProgressMeter.update!(prog, max(progress_nsteps,progress_tol))
+        if progress
+            progress_nsteps = round(Int,100*(i-1)/(nsteps-1))
+            progress_tol = round(Int,100^min(1, (log10(res/res₀)) / log10(tol/res₀)))
+            ProgressMeter.update!(prog, max(progress_nsteps,progress_tol))
+        end
     end
     ProgressMeter.finish!(prog)
     hist == nothing ? bestx : (bestx, _hist)

--- a/src/sampling.jl
+++ b/src/sampling.jl
@@ -215,7 +215,7 @@ function sample_joint(
         end
         
         ϕstarts = if (ϕstart == 0) 
-            fill(zero(ds().Cϕ.diag), nchains)
+            fill(batch(zero(diag(ds().Cϕ)),batchsize(ds.d)), nchains)
         elseif ϕstart isa Field
             fill(ϕstart, nchains)
         elseif ϕstart in [:quasi_sample, :best_fit]

--- a/src/specialops.jl
+++ b/src/specialops.jl
@@ -321,8 +321,8 @@ pinv(L::OuterProdOp{<:LazyBinaryOp{*}}) = (_check_sym(L); OuterProdOp(pinv(L.V.a
 adjoint(L::OuterProdOp) = OuterProdOp(L.W,L.V)
 adapt_structure(to, L::OuterProdOp) = OuterProdOp((V′=adapt(to,L.V);), (L.V === L.W ? V′ : adapt(to,L.W)))
 diag(L::OuterProdOp{<:Field{B},<:Field}) where {B} = L.V .* conj.(B(L.W))
-*(D::DiagOp{<:Field{B}}, L::OuterProdOp{<:Field{B},<:Field{B}}) where {B} = OuterProdOp(diag(D)*L.V, L.W)
-*(L::OuterProdOp{<:Field{B},<:Field{B}}, D::DiagOp{<:Field{B}}) where {B} = OuterProdOp(L.V, L.W*diag(D))
+*(D::DiagOp{<:Field{B}}, L::OuterProdOp{<:Field{B},<:Field{B}}) where {B} = OuterProdOp(diag(D) .* L.V, L.W)
+*(L::OuterProdOp{<:Field{B},<:Field{B}}, D::DiagOp{<:Field{B}}) where {B} = OuterProdOp(L.V, L.W .* diag(D))
 tr(L::OuterProdOp{<:Field{B},<:Field{B}}) where {B} = dot(L.V, L.W)
 
 

--- a/src/specialops.jl
+++ b/src/specialops.jl
@@ -235,8 +235,7 @@ function (L::ParamDependentOp)(;θ...)
         # https://discourse.julialang.org/t/can-zygote-do-derivatives-w-r-t-keyword-arguments-which-get-captured-in-kwargs/34553/8
         # dependent_θ = filter(((k,_),)->k in L.parameters, pairs(θ))
         
-        # type annotation here for if any Core.Box'ed variables slipped into our recompute_function:
-        L.recompute_function(;θ...) :: typeof(L.op)
+        L.recompute_function(;θ...)
     else
         L.op
     end 

--- a/src/util.jl
+++ b/src/util.jl
@@ -497,10 +497,10 @@ firsthalf(x) = x[1:end÷2]
 lasthalf(x) = x[end÷2:end]
 
 
-function sum_kbn(A; dims=:)
-    if (dims == (:)) || (ndims(A) == length(dims))
+function sum_kbn(A::Array{T,N}; dims=:) where {T,N}
+    if (dims == (:)) || (N == length(dims))
         KahanSummation.sum_kbn(A)
     else
-        dropdims(mapslices(sum_kbn, A, dims=dims), dims=dims)
+        dropdims(mapslices(sum_kbn, A, dims=dims), dims=dims) :: Array{T,N-length(dims)}
     end
 end

--- a/src/util.jl
+++ b/src/util.jl
@@ -495,3 +495,12 @@ end
 
 firsthalf(x) = x[1:end÷2]
 lasthalf(x) = x[end÷2:end]
+
+
+function sum_kbn(A; dims=:)
+    if (dims == (:)) || (ndims(A) == length(dims))
+        KahanSummation.sum_kbn(A)
+    else
+        dropdims(mapslices(sum_kbn, A, dims=dims), dims=dims)
+    end
+end

--- a/src/util_fft.jl
+++ b/src/util_fft.jl
@@ -35,7 +35,7 @@ N×N one via symmetries.
 """
 unfold(Tls::AbstractArray{<:Complex,3}) = mapslices(unfold, Tls, dims=(1,2))
 unfold(Tl::AbstractMatrix{<:Complex}) = unfold(Array(Tl))
-function unfold(Tl::AbstractMatrix{<:Complex})
+function unfold(Tl::Matrix{<:Complex})
     m,n = size(Tl)
     @assert m==n÷2+1
     m2 = iseven(n) ? 2m : 2m+1

--- a/src/util_fft.jl
+++ b/src/util_fft.jl
@@ -33,12 +33,13 @@ end
 Convert an M×N matrix (with M=N÷2+1) which is the output a real FFT to a full
 N×N one via symmetries.
 """
-unfold(Tl::AbstractMatrix) = unfold(Array(Tl))
-function unfold(Tl::Matrix{Complex{T}}) where {T}
+unfold(Tls::AbstractArray{<:Complex,3}) = mapslices(unfold, Tls, dims=(1,2))
+unfold(Tl::AbstractMatrix{<:Complex}) = unfold(Array(Tl))
+function unfold(Tl::AbstractMatrix{<:Complex})
     m,n = size(Tl)
     @assert m==n÷2+1
     m2 = iseven(n) ? 2m : 2m+1
-    Tlu = Array{Complex{T}}(undef,n,n)
+    Tlu = similar(Tl,n,n)
     Tlu[1:m,1:n] = Tl
     @inbounds for i=m+1:n
         Tlu[i,1] = Tl[m2-i, 1]'

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -141,6 +141,7 @@ end
         (BasisTuple{Tuple{Fourier,EBFourier}}, FlatIQUMap(rand(4,4),rand(4,4),rand(4,4))), # named nested FieldTuple,
         (BasisTuple{Tuple{Fourier,EBFourier}}, FieldTuple(FlatMap(rand(4,4)),FlatQUMap(rand(4,4),rand(4,4)))), # unnamed nested FieldTuple
         (Fourier,   FlatMap(rand(4,4,2))), # batched S0 
+        (Fourier,   FlatQUMap(rand(4,4,2),rand(4,4,2))), # batched S2
     ]
     
     for (B,f) in fs

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,7 @@
 using CMBLensing
 using CMBLensing: 
     @SMatrix, @SVector, AbstractCℓs, basis, Basis, BasisTuple,
-    LinearInterpolation, Measurement, RK4Solver, seed!, ±
+    LinearInterpolation, Measurement, RK4Solver, seed!, ±, batchsize
 
 ##
 
@@ -180,7 +180,7 @@ end
             
             # Field dot products
             D = Diagonal(f)
-            if f isa FlatField && batchlength(f)>1 # batched fields not inferred
+            if f isa FlatField && batchsize(f)>1 # batched fields not inferred
                 @test (f' * f) isa Real
                 @test (f' * B(f)) isa Real
                 @test (f' * D * f) isa Real

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,8 @@
 using CMBLensing
 using CMBLensing: 
     @SMatrix, @SVector, AbstractCℓs, basis, Basis, BasisTuple,
-    LinearInterpolation, Measurement, RK4Solver, seed!, ±, batchsize
+    LinearInterpolation, Measurement, RK4Solver, seed!, ±, batchsize, basetype,
+    unbatch, batchindex
 
 ##
 
@@ -253,6 +254,27 @@ end
 end
 
 ##
+
+@testset "BatchedReal" begin
+    
+    r  = 1.
+    rb = batch([1.,2])
+    
+    for (f,fb) in [
+        (  FlatMap(rand(8,8)),           FlatMap(rand(8,8,2))),
+        (FlatQUMap(rand(8,8),rand(8,8)), FlatQUMap(rand(8,8,2),rand(8,8,2)))
+    ]
+        @testset "f :: $(typeof(f))" begin
+            @test @inferred(r * f)  == f
+            @test @inferred(r * fb) == fb
+            @test unbatch(@inferred(rb * f)) == [f, 2f]
+            @test unbatch(@inferred(rb * fb)) == [batchindex(fb,1), 2batchindex(fb,2)]
+        end
+    end
+    
+end
+
+## 
 
 @testset "Gradients" begin
     

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,8 +1,7 @@
 using CMBLensing
 using CMBLensing: 
     @SMatrix, @SVector, AbstractCℓs, basis, Basis, BasisTuple,
-    LinearInterpolation, Measurement, RK4Solver, seed!, ±, batchsize, basetype,
-    unbatch, batchindex
+    LinearInterpolation, Measurement, RK4Solver, seed!, ±
 
 ##
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -139,7 +139,8 @@ end
         (EBFourier, FlatQUMap(rand(4,4),rand(4,4))), # named FieldTuple
         (Fourier,   FieldTuple(FlatMap(rand(4,4)),FlatMap(rand(4,4)))), # unnamed FieldTuple
         (BasisTuple{Tuple{Fourier,EBFourier}}, FlatIQUMap(rand(4,4),rand(4,4),rand(4,4))), # named nested FieldTuple,
-        (BasisTuple{Tuple{Fourier,EBFourier}}, FieldTuple(FlatMap(rand(4,4)),FlatQUMap(rand(4,4),rand(4,4)))) # unnamed nested FieldTuple
+        (BasisTuple{Tuple{Fourier,EBFourier}}, FieldTuple(FlatMap(rand(4,4)),FlatQUMap(rand(4,4),rand(4,4)))), # unnamed nested FieldTuple
+        (Fourier,   FlatMap(rand(4,4,2))), # batched S0 
     ]
     
     for (B,f) in fs
@@ -179,9 +180,15 @@ end
             
             # Field dot products
             D = Diagonal(f)
-            @test (@inferred f' * f) isa Real
-            @test (@inferred f' * B(f)) isa Real
-            @test (@inferred f' * D * f) isa Real
+            if f isa FlatField && batchlength(f)>1 # batched fields not inferred
+                @test (f' * f) isa Real
+                @test (f' * B(f)) isa Real
+                @test (f' * D * f) isa Real
+            else
+                @test (@inferred f' * f) isa Real
+                @test (@inferred f' * B(f)) isa Real
+                @test (@inferred f' * D * f) isa Real
+            end
             @test sum(f, dims=:) ≈ sum(f[:])
             @test_throws Any sum(f, dims=1)
             @test sum(f, dims=2) == f


### PR DESCRIPTION
This adds "batched" Flat fields which behave just like normal fields but actually store several "batches" of fields at once. The motivation is to speed up GPU code, which is currently only using about 20% of a Tesla V100, due to having to wait on results of FFT kernels. Since we can't speed those up, the solution is to just do more of them in parallel. However, we only get the full speedup if we actually batch the field data together so kernels can efficiently go through it all at once, hence batched fields. 

You can create batched fields in several ways:

```julia
FlatMap(rand(128,128,4)) # a batch of 4 128×128 fields
batch([f,f,f,f]) # put four non-batched fields `f` together in a single batch-4 field
batch(f,4) # same as above but data not actually copied four times
```

All code pretty much works transparently on batched fields as it does on normal fields, but just does everything in batches. This includes everything up to posterior gradients, sampling, etc... The only difference is that operations that return a scalar now return a `BatchedReal` (which itself can be added, multiplied, etc... as if it were a `Real`):

```julia
julia> dot(FlatMap(rand(128,128,4)), FlatMap(rand(128,128,4)))
BatchedFloat64[4114.738009871811, 4105.554880583013, 4109.014277485975, 4109.830420691169]
```

On a Tesla V100, some timings for a 256×256 Float32 mixed posterior gradient:

```
┌────────┬───────────┬─────────┐
│ Time   │ Batchsize │ Speedup │
├────────┼───────────┼─────────┤
│ 120 ms │         1 │    1.0× │
│ 192 ms │         2 │    1.3× │
│ 196 ms │         4 │    2.4× │
│ 217 ms │         8 │    4.4× │
│ 345 ms │        16 │    5.6× │
└────────┴───────────┴─────────┘
```

Looks like the sweet-spot for per-gradient speed-up while not hurting overall sequential runtime is somewhere near batchsize of 10 and we get about a 5x speedup. 