### PR TITLE
Add QQ, UU, QU indexing to Fourier-diagonal EB covariances

### DIFF
--- a/src/flat_s0s2.jl
+++ b/src/flat_s0s2.jl
@@ -114,6 +114,7 @@ function getindex(L::FlatIEBCov, k::Symbol)
         :E => L.ΣTE[2,2]
         :B => L.ΣB
         :P => Diagonal(FlatEBFourier(L[:E].diag, L[:B].diag))
+        (:QQ || :UU || :QU || :UQ) => getindex(L[:P], k)
         _ => throw(ArgumentError("Invalid FlatIEBCov index: $k"))
     end
 end

--- a/src/flat_s2.jl
+++ b/src/flat_s2.jl
@@ -74,6 +74,26 @@ function getindex(f::FlatS2, k::Symbol)
     getproperty(B(f),k)
 end
 
+function Base.getindex(D::DiagOp{<:FlatEBFourier}, s::Symbol)
+    @unpack El, Bl = diag(D);
+    @unpack sin2ϕ, cos2ϕ, P = fieldinfo(diag(D))
+    if   s === :QQ
+        return Diagonal(FlatFourier{P}(@. Bl*sin2ϕ^2 + El*cos2ϕ^2))
+    elseif s === :UU
+        return Diagonal(FlatFourier{P}(@. Bl*cos2ϕ^2 + El*sin2ϕ^2))
+    elseif s === :QU
+        return Diagonal(FlatFourier{P}(@. (El - Bl) * sin2ϕ * cos2ϕ))
+    else
+        Diagonal(getproperty(D.diag,s))
+    end
+    
+end
+
+function Base.getindex(C::ParamDependentOp{EBFourier, S, P, <:DiagOp}, s::Symbol) where {S, P}
+    ParamDependentOp(C.op[s], C.recompute_function, C.parameters)
+end
+
+
 ### basis conversion
 
 QUFourier(f::FlatQUMap) = FlatQUFourier(map(Fourier,f.fs))

--- a/src/specialops.jl
+++ b/src/specialops.jl
@@ -229,6 +229,7 @@ end
 for F in (:inv, :pinv, :sqrt, :adjoint, :Diagonal, :diag, :simulate, :zero, :one, :logdet, :global_rng_for)
     @eval $F(L::ParamDependentOp) = $F(L.op)
 end
+getindex(L::ParamDependentOp, x) = getindex(L.op, x)
 simulate(rng::AbstractRNG, L::ParamDependentOp) = simulate(rng, L.op)
 depends_on(L::ParamDependentOp, θ) = depends_on(L, keys(θ))
 depends_on(L::ParamDependentOp, θ::Tuple) = isempty(L.parameters) || any(L.parameters .∈ Ref(θ))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -232,6 +232,12 @@ end
 
 ##
 
+@testset "FlatS2" begin
+    C = Diagonal(EBFourier(FlatEBMap(rand(3,3), rand(3,3))))
+    f = FlatQUMap(rand(3,3), rand(3,3))
+    @test C*f ≈ FlatQUFourier(C[:QQ]*f[:Q]+C[:QU]*f[:U], C[:UU]*f[:U]+C[:UQ]*f[:Q])
+end
+
 @testset "FlatS02" begin
     
     ΣTT, ΣTE, ΣEE, ΣBB = [Diagonal(Fourier(FlatMap(rand(3,3)))) for i=1:4]


### PR DESCRIPTION
This PR adds functionality to rotate EB covariances into QQ, UU, and QU covariances (if the EB covariance is diagonal in Fourier space.)

I think this needs to be implemented separately for FlatS2s and FlatS02s?