### PR TITLE
first pass non-square map for flat sky

### DIFF
--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -125,7 +125,8 @@ and simulated truths. E.g.
     T     = Float32
 );
 ```
-
+For rectangular maps, Nside expects (Ny, Nx), i.e. (Nrow, Ncol). 
+If Nside isa Int, the code interprets it as a square map.
 """
 function load_sim(;
     
@@ -211,7 +212,7 @@ function load_sim(;
         Pix_data = Pix
         P = 1
     else
-        Pix_data = Flat(Nside=Nside÷(θpix_data÷θpix), θpix=θpix_data, ∂mode=∂mode)
+        Pix_data = Flat(Nside=Nside.÷(θpix_data÷θpix), θpix=θpix_data, ∂mode=∂mode)
         P = FuncOp(
             op  = f -> ud_grade(f, θpix_data, deconv_pixwin=false, anti_aliasing=false),
             opᴴ = f -> ud_grade(f, θpix,      deconv_pixwin=false, anti_aliasing=false)

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -232,7 +232,7 @@ function load_sim(;
     if (M == nothing)
         Mfourier = adapt(storage, Cℓ_to_Cov(Pix_data, T, S, ((k==:TE ? 0 : 1) * bandpass_mask.diag.Wℓ for k in ks)...; units=1))
         if (pixel_mask_kwargs != nothing)
-            Mpix = adapt(storage, Diagonal(F{Pix_data}(repeated(T.(make_mask(Nside÷(θpix_data÷θpix),θpix_data; pixel_mask_kwargs...).Ix),nF)...)))
+            Mpix = adapt(storage, Diagonal(F{Pix_data}(repeated(T.(make_mask(Nside.÷(θpix_data÷θpix),θpix_data; pixel_mask_kwargs...).Ix),nF)...)))
         else
             Mpix = 1
         end

--- a/src/field_tuples.jl
+++ b/src/field_tuples.jl
@@ -154,6 +154,10 @@ function ud_grade(f::FieldTuple, args...; kwargs...)
     FieldTuple(map(f->ud_grade(f,args...; kwargs...), f.fs))
 end
 
+# logdet & trace
+logdet(L::Diagonal{<:Union{Real,Complex}, <:FieldTuple}) = sum(map(logdet∘Diagonal,L.diag.fs))
+tr(L::Diagonal{<:Union{Real,Complex}, <:FieldTuple}) = sum(map(tr∘Diagonal,L.diag.fs))
+
 # misc
 fieldinfo(ft::FieldTuple) = fieldinfo(only(unique(map(typeof, ft.fs)))) # todo: make even more generic
 batchsize(ft::FieldTuple) = only(unique(map(batchsize, ft.fs)))

--- a/src/flat_fftgrid.jl
+++ b/src/flat_fftgrid.jl
@@ -7,7 +7,7 @@ struct fourier∂ <: ∂modes end
 struct map∂ <: ∂modes end
 promote_rule(::Type{map∂}, ::Type{fourier∂}) = fourier∂
 
-# Flat{Nside,θpix,∂mode} is a flat sky pixelization with `Nside` pixels per side
+# Flat{Nside,θpix,∂mode} is a flat sky pixelization with `Nside` pixels per side for (Ny, Nx)
 # and pixels of width `θpix` arcmins, where derivatives are done according to ∂mode
 abstract type Flat{Nside,θpix,∂mode<:∂modes,D} <: Pix end
 
@@ -42,7 +42,7 @@ function FlatInfo(T, Arr, θpix, Nside, D)
 
     FFTW.set_num_threads(FFTW_NUM_THREADS)
 
-    Nx, Ny = Nside .* (1,1)
+    Ny, Nx = Nside .* (1,1)
     Δx   = T(deg2rad(θpix/60))
     FFT  = plan_rfft(Arr{T}(undef,Ny,Nx,(D==1 ? () : (D,))...), (1,2); (Arr <: Array ? (timelimit=FFTW_TIMELIMIT,) : ())...)
     Δℓx  = T(2π/(Nx*Δx))

--- a/src/flat_fftgrid.jl
+++ b/src/flat_fftgrid.jl
@@ -42,16 +42,15 @@ function FlatInfo(T, Arr, θpix, Nside, D)
 
     FFTW.set_num_threads(FFTW_NUM_THREADS)
 
-    typeof(Nside) <: Tuple ? (Nx, Ny)=Nside : Nx = Ny = Nside 
-
+    Nx, Ny = Nside .* (1,1)
     Δx   = T(deg2rad(θpix/60))
     FFT  = plan_rfft(Arr{T}(undef,Ny,Nx,(D==1 ? () : (D,))...), (1,2); (Arr <: Array ? (timelimit=FFTW_TIMELIMIT,) : ())...)
-    Δℓx   = T(2π/(Nx*Δx))
-    Δℓy   = T(2π/(Ny*Δx))
+    Δℓx  = T(2π/(Nx*Δx))
+    Δℓy  = T(2π/(Ny*Δx))
     nyq  = T(2π/(2Δx))
     Ωpix = T(Δx^2)
-    ky  = ifftshift(-Ny÷2:(Ny-1)÷2) .* Δℓy
-    kx  = ifftshift(-Nx÷2:(Nx-1)÷2) .* Δℓx
+    ky   = ifftshift(-Ny÷2:(Ny-1)÷2) .* Δℓy
+    kx   = ifftshift(-Nx÷2:(Nx-1)÷2) .* Δℓx
     kmag = @. sqrt(kx'^2 + ky^2)
     ϕ    = @. angle(kx' + im*ky)[1:Ny÷2+1,:]
     sin2ϕ, cos2ϕ = @. sin(2ϕ), cos(2ϕ)
@@ -59,7 +58,7 @@ function FlatInfo(T, Arr, θpix, Nside, D)
         sin2ϕ[end, end:-1:(Nx÷2+2)] .= sin2ϕ[end, 2:Nx÷2]
     end
     
-    @namedtuple(T, θpix, Nx, Ny, Δx, Δℓx, Δℓy, nyq, Ωpix, kx, ky, kmag, sin2ϕ=Arr(sin2ϕ), cos2ϕ=Arr(cos2ϕ), FFT)
+    @namedtuple(T, θpix, Nx, Ny, Nside, Δx, Δℓx, Δℓy, nyq, Ωpix, kx, ky, kmag, sin2ϕ=Arr(sin2ϕ), cos2ϕ=Arr(cos2ϕ), FFT)
 
 end
 

--- a/src/flat_generic.jl
+++ b/src/flat_generic.jl
@@ -5,7 +5,7 @@ const FlatFieldFourier{P,T,M} = Union{FlatFourier{P,T,M},FlatS2{P,T,M},FlatS02Fo
 
 ### pretty printing
 @show_datatype show_datatype(io::IO, t::Type{F}) where {N,θ,∂mode,D,T,M,F<:FlatField{Flat{N,θ,∂mode,D},T,M}} =
-    print(io, "$(pretty_type_name(F)){$(N)×$(N)$(D==1 ? "" : "(×$D)") map, $(θ)′ pixels, $(∂mode.name.name), $M}")
+print(io, "$(pretty_type_name(F)){$( typeof(N) <: Tuple ? N[2] : N )×$(  typeof(N) <: Tuple ? N[1] : N )$(D==1 ? "" : "(×$D)") map, $(θ)′ pixels, $(∂mode.name.name), $M}")
 for F in (:FlatMap, :FlatFourier, 
           :FlatQUMap, :FlatQUFourier, :FlatEBMap, :FlatEBFourier, 
           :FlatIQUMap, :FlatIQUFourier, :FlatIEBMap, :FlatIEBFourier)
@@ -55,11 +55,11 @@ DerivBasis(::Type{<:FlatS02{<:Flat{<:Any,<:Any,map∂}}})     = IQUMap
 # without the @generated it triggers an order-dependenant compilation bug which
 # e.g. slows down LenseFlow by a factor of ~4 so we gotta keep it for now ¯\_(ツ)_/¯
 @generated broadcastable(::Type{F}, ::∇diag{1,<:Any,prefactor}) where {P,T,M,prefactor,F<:FlatFourier{P,T,M}} = 
-    basetype(M)(@. prefactor * im * $fieldinfo(F).k')
+    basetype(M)(@. prefactor * im * $fieldinfo(F).kx')
 @generated broadcastable(::Type{F}, ::∇diag{2,<:Any,prefactor}) where {N,P<:Flat{N},T,M,prefactor,F<:FlatFourier{P,T,M}} = 
-    basetype(M)(@. prefactor * im * $fieldinfo(F).k[1:N÷2+1])
+    basetype(M)(@. prefactor * im * $fieldinfo(F).ky[1:$fieldinfo(F).Ny÷2+1])
 @generated broadcastable(::Type{F}, ::∇²diag) where {N,P<:Flat{N},T,M,F<:FlatFourier{P,T,M}} =
-    basetype(M)(@. $fieldinfo(F).k'^2 + $fieldinfo(F).k[1:N÷2+1]^2)
+    basetype(M)(@. $fieldinfo(F).kx'^2 + $fieldinfo(F).ky[1:$fieldinfo(F).Ny÷2+1]^2)
 
 ## Map-space
 function copyto!(f′::F, bc::Broadcasted{<:Any,<:Any,typeof(*),Tuple{∇diag{coord,covariant,prefactor},F}}) where {coord,covariant,prefactor,T,θ,N,D,F<:FlatMap{Flat{N,θ,map∂,D},T}}
@@ -99,14 +99,14 @@ broadcastable(::Type{F}, bp::BandPass) where {P,T,F<:FlatFourier{P,T}} = Cℓ_to
     
 
 ### logdets
-logdet(L::Diagonal{<:Complex,<:FlatFourier})   = batch(real(sum_kbn(nan2zero.(log.(unfold(L.diag.Il))),dims=(1,2))))
+logdet(L::Diagonal{<:Complex,<:FlatFourier})   = batch(real(sum_kbn(nan2zero.(log.(unfold(L.diag.Il, fieldinfo(L.diag).Ny))),dims=(1,2))))
 logdet(L::Diagonal{<:Real,<:FlatMap})          = batch(real(sum_kbn(nan2zero.(log.(complex(L.diag.Ix))),dims=(1,2))))
-logdet(L::Diagonal{<:Complex,<:FlatEBFourier}) = batch(real(sum_kbn(nan2zero.(log.(unfold(L.diag.El))),dims=(1,2)) + sum_kbn(nan2zero.(log.(unfold(L.diag.Bl))),dims=(1,2))))
+logdet(L::Diagonal{<:Complex,<:FlatEBFourier}) = batch(real(sum_kbn(nan2zero.(log.(unfold(L.diag.El, fieldinfo(L.diag).Ny))),dims=(1,2)) + sum_kbn(nan2zero.(log.(unfold(L.diag.Bl, fieldinfo(L.diag).Ny))),dims=(1,2))))
 ### traces
-tr(L::Diagonal{<:Complex,<:FlatFourier})   = batch(real(sum_kbn(unfold(L.diag.Il),dims=(1,2))))
+tr(L::Diagonal{<:Complex,<:FlatFourier})   = batch(real(sum_kbn(unfold(L.diag.Il, fieldinfo(L.diag).Ny ),dims=(1,2))))
 tr(L::Diagonal{<:Real,<:FlatMap})          = batch(real(sum_kbn(complex(L.diag.Ix),dims=(1,2))))
-tr(L::Diagonal{<:Complex,<:FlatEBFourier}) = batch(real(sum_kbn(unfold(L.diag.El),dims=(1,2)) + sum_kbn(unfold(L.diag.Bl),dims=(1,2))))
-tr(L::Diagonal{<:Complex,<:FlatQUFourier}) = batch(real(sum_kbn(unfold(L.diag.Ql),dims=(1,2)) + sum_kbn(unfold(L.diag.Ul),dims=(1,2))))
+tr(L::Diagonal{<:Complex,<:FlatEBFourier}) = batch(real(sum_kbn(unfold(L.diag.El, fieldinfo(L.diag).Ny),dims=(1,2)) + sum_kbn(unfold(L.diag.Bl, fieldinfo(L.diag).Ny ),dims=(1,2))))
+tr(L::Diagonal{<:Complex,<:FlatQUFourier}) = batch(real(sum_kbn(unfold(L.diag.Ql, fieldinfo(L.diag).Ny),dims=(1,2)) + sum_kbn(unfold(L.diag.Ul, fieldinfo(L.diag).Ny),dims=(1,2))))
 
 
 ### misc

--- a/src/flat_generic.jl
+++ b/src/flat_generic.jl
@@ -5,7 +5,7 @@ const FlatFieldFourier{P,T,M} = Union{FlatFourier{P,T,M},FlatS2{P,T,M},FlatS02Fo
 
 ### pretty printing
 @show_datatype show_datatype(io::IO, t::Type{F}) where {N,θ,∂mode,D,T,M,F<:FlatField{Flat{N,θ,∂mode,D},T,M}} =
-print(io, "$(pretty_type_name(F)){$( typeof(N) <: Tuple ? N[2] : N )×$(  typeof(N) <: Tuple ? N[1] : N )$(D==1 ? "" : "(×$D)") map, $(θ)′ pixels, $(∂mode.name.name), $M}")
+print(io, "$(pretty_type_name(F)){$(join(N .* (1,1), "×"))$(D==1 ? "" : "(×$D)") map, $(θ)′ pixels, $(∂mode.name.name), $M}")
 for F in (:FlatMap, :FlatFourier, 
           :FlatQUMap, :FlatQUFourier, :FlatEBMap, :FlatEBFourier, 
           :FlatIQUMap, :FlatIQUFourier, :FlatIEBMap, :FlatIEBFourier)

--- a/src/flat_generic.jl
+++ b/src/flat_generic.jl
@@ -108,8 +108,8 @@ broadcastable(::Type{F}, bp::BandPass) where {P,T,F<:FlatFourier{P,T}} = Cℓ_to
 logdet(L::Diagonal{<:Complex,<:FlatFourier}) = batch(real(sum_kbn(nan2zero.(log.(L.diag[:Il,full_plane=true])),dims=(1,2))))
 logdet(L::Diagonal{<:Real,   <:FlatMap})     = batch(real(sum_kbn(nan2zero.(log.(complex.(L.diag.Ix))),dims=(1,2))))
 ### traces
-tr(L::Diagonal{<:Complex,<:FlatFourier}) = batch(real(sum_kbn(L.diag[:Il,full_plane=true]),dims=(1,2)))
-tr(L::Diagonal{<:Real,   <:FlatMap})     = batch(real(sum_kbn(complex.(L.diag.Ix)),dims=(1,2)))
+tr(L::Diagonal{<:Complex,<:FlatFourier}) = batch(real(sum_kbn(L.diag[:Il,full_plane=true],dims=(1,2))))
+tr(L::Diagonal{<:Real,   <:FlatMap})     = batch(real(sum_kbn(complex.(L.diag.Ix),dims=(1,2))))
 
 
 ### misc

--- a/src/flat_generic.jl
+++ b/src/flat_generic.jl
@@ -54,12 +54,18 @@ DerivBasis(::Type{<:FlatS02{<:Flat{<:Any,<:Any,map∂}}})     = IQUMap
 # these are only 1-d arrays, that's a completely unnecessary optimization, but
 # without the @generated it triggers an order-dependenant compilation bug which
 # e.g. slows down LenseFlow by a factor of ~4 so we gotta keep it for now ¯\_(ツ)_/¯
-@generated broadcastable(::Type{F}, ::∇diag{1,<:Any,prefactor}) where {P,T,M,prefactor,F<:FlatFourier{P,T,M}} = 
-    basetype(M)(@. prefactor * im * $fieldinfo(F).kx')
-@generated broadcastable(::Type{F}, ::∇diag{2,<:Any,prefactor}) where {N,P<:Flat{N},T,M,prefactor,F<:FlatFourier{P,T,M}} = 
-    basetype(M)(@. prefactor * im * $fieldinfo(F).ky[1:$fieldinfo(F).Ny÷2+1])
-@generated broadcastable(::Type{F}, ::∇²diag) where {N,P<:Flat{N},T,M,F<:FlatFourier{P,T,M}} =
-    basetype(M)(@. $fieldinfo(F).kx'^2 + $fieldinfo(F).ky[1:$fieldinfo(F).Ny÷2+1]^2)
+@generated function broadcastable(::Type{F}, ::∇diag{1,<:Any,prefactor}) where {P,T,M,prefactor,F<:FlatFourier{P,T,M}}
+    @unpack kx = fieldinfo(F)
+    basetype(M)(@. prefactor * im * kx')
+end
+@generated function broadcastable(::Type{F}, ::∇diag{2,<:Any,prefactor}) where {P,T,M,prefactor,F<:FlatFourier{P,T,M}}
+    @unpack ky, Ny = fieldinfo(F)
+    basetype(M)(@. prefactor * im * ky[1:Ny÷2+1])
+end
+@generated function broadcastable(::Type{F}, ::∇²diag) where {P,T,M,F<:FlatFourier{P,T,M}}
+    @unpack kx, ky, Ny = fieldinfo(F)
+    basetype(M)(@. kx'^2 + ky[1:Ny÷2+1]^2)
+end
 
 ## Map-space
 function copyto!(f′::F, bc::Broadcasted{<:Any,<:Any,typeof(*),Tuple{∇diag{coord,covariant,prefactor},F}}) where {coord,covariant,prefactor,T,θ,N,D,F<:FlatMap{Flat{N,θ,map∂,D},T}}
@@ -99,14 +105,11 @@ broadcastable(::Type{F}, bp::BandPass) where {P,T,F<:FlatFourier{P,T}} = Cℓ_to
     
 
 ### logdets
-logdet(L::Diagonal{<:Complex,<:FlatFourier})   = batch(real(sum_kbn(nan2zero.(log.(unfold(L.diag.Il, fieldinfo(L.diag).Ny))),dims=(1,2))))
-logdet(L::Diagonal{<:Real,<:FlatMap})          = batch(real(sum_kbn(nan2zero.(log.(complex(L.diag.Ix))),dims=(1,2))))
-logdet(L::Diagonal{<:Complex,<:FlatEBFourier}) = batch(real(sum_kbn(nan2zero.(log.(unfold(L.diag.El, fieldinfo(L.diag).Ny))),dims=(1,2)) + sum_kbn(nan2zero.(log.(unfold(L.diag.Bl, fieldinfo(L.diag).Ny))),dims=(1,2))))
+logdet(L::Diagonal{<:Complex,<:FlatFourier}) = batch(real(sum_kbn(nan2zero.(log.(L.diag[:Il,full_plane=true])),dims=(1,2))))
+logdet(L::Diagonal{<:Real,   <:FlatMap})     = batch(real(sum_kbn(nan2zero.(log.(complex.(L.diag.Ix))),dims=(1,2))))
 ### traces
-tr(L::Diagonal{<:Complex,<:FlatFourier})   = batch(real(sum_kbn(unfold(L.diag.Il, fieldinfo(L.diag).Ny ),dims=(1,2))))
-tr(L::Diagonal{<:Real,<:FlatMap})          = batch(real(sum_kbn(complex(L.diag.Ix),dims=(1,2))))
-tr(L::Diagonal{<:Complex,<:FlatEBFourier}) = batch(real(sum_kbn(unfold(L.diag.El, fieldinfo(L.diag).Ny),dims=(1,2)) + sum_kbn(unfold(L.diag.Bl, fieldinfo(L.diag).Ny ),dims=(1,2))))
-tr(L::Diagonal{<:Complex,<:FlatQUFourier}) = batch(real(sum_kbn(unfold(L.diag.Ql, fieldinfo(L.diag).Ny),dims=(1,2)) + sum_kbn(unfold(L.diag.Ul, fieldinfo(L.diag).Ny),dims=(1,2))))
+tr(L::Diagonal{<:Complex,<:FlatFourier}) = batch(real(sum_kbn(L.diag[:Il,full_plane=true]),dims=(1,2)))
+tr(L::Diagonal{<:Real,   <:FlatMap})     = batch(real(sum_kbn(complex.(L.diag.Ix)),dims=(1,2)))
 
 
 ### misc

--- a/src/flat_s0.jl
+++ b/src/flat_s0.jl
@@ -41,7 +41,7 @@ size(f::FlatS0) = (length(firstfield(f)),)
 lastindex(f::FlatS0, i::Int) = lastindex(f.Ix, i)
 # content_size and content_ndims refer to the actual array holding the field content:
 content_size(::Type{<:FlatMap{    <:Flat{N,<:Any,<:Any,D}}}) where {N,D} = (reverse(N .* (1,1)         )..., (D==1 ? () : (D,))...)
-content_size(::Type{<:FlatFourier{<:Flat{N,<:Any,<:Any,D}}}) where {N,D} = (reverse(N .÷ (2,1) .+ (1,0))..., (D==1 ? () : (D,))...)
+content_size(::Type{<:FlatFourier{<:Flat{N,<:Any,<:Any,D}}}) where {N,D} = (reverse(N .÷ (1,2) .+ (0,1))..., (D==1 ? () : (D,))...)
 content_ndims(::Type{<:FlatS0{<:Flat{<:Any,<:Any,<:Any,D}}}) where {D} = D==1 ? 3 : 2
 @propagate_inbounds @inline getindex(f::FlatS0, I...) = getindex(firstfield(f), I...)
 @propagate_inbounds @inline setindex!(f::FlatS0, X, I...) = (setindex!(firstfield(f), X, I...); f)

--- a/src/flat_s0.jl
+++ b/src/flat_s0.jl
@@ -27,7 +27,7 @@ for (F, X, T) in [
     """
     @eval begin
         @doc $doc $F
-        $F($X::AbstractRank2or3Array; kwargs...) = $F{Flat(Nside=size($X)[[2,1]],D=size($X,3);kwargs...)}($X)
+        $F($X::AbstractRank2or3Array; kwargs...) = $F{Flat(Nside=size($X)[1:2],D=size($X,3);kwargs...)}($X)
         $F{P}($X::M) where {P,T,M<:AbstractRank2or3Array{$T}} = $F{P,T,M}($X)
         $F{P,T}($X::AbstractRank2or3Array) where {P,T} = $F{P}($T.($X))
     end

--- a/src/flat_s0.jl
+++ b/src/flat_s0.jl
@@ -40,8 +40,8 @@ end
 size(f::FlatS0) = (length(firstfield(f)),)
 lastindex(f::FlatS0, i::Int) = lastindex(f.Ix, i)
 # content_size and content_ndims refer to the actual array holding the field content:
-content_size(::Type{<:FlatMap{    <:Flat{N,<:Any,<:Any,D}}}) where {N,D} = (reverse(N .* (1,1)         )..., (D==1 ? () : (D,))...)
-content_size(::Type{<:FlatFourier{<:Flat{N,<:Any,<:Any,D}}}) where {N,D} = (reverse(N .÷ (1,2) .+ (0,1))..., (D==1 ? () : (D,))...)
+content_size(::Type{<:FlatMap{    <:Flat{N,<:Any,<:Any,D}}}) where {N,D} = (N .* (1,1)         ..., (D==1 ? () : (D,))...)
+content_size(::Type{<:FlatFourier{<:Flat{N,<:Any,<:Any,D}}}) where {N,D} = (N .÷ (2,1) .+ (1,0)..., (D==1 ? () : (D,))...)
 content_ndims(::Type{<:FlatS0{<:Flat{<:Any,<:Any,<:Any,D}}}) where {D} = D==1 ? 3 : 2
 @propagate_inbounds @inline getindex(f::FlatS0, I...) = getindex(firstfield(f), I...)
 @propagate_inbounds @inline setindex!(f::FlatS0, X, I...) = (setindex!(firstfield(f), X, I...); f)

--- a/src/flat_s0s2.jl
+++ b/src/flat_s0s2.jl
@@ -58,13 +58,13 @@ getproperty(f::FlatIQU, s::Union{Val{:Q},Val{:U}}) = getproperty(getfield(f,:fs)
 getproperty(f::FlatIEB, s::Union{Val{:E},Val{:B}}) = getproperty(getfield(f,:fs).P,s)
 getproperty(f::FlatS02, s::Union{Val{:Qx},Val{:Ux},Val{:Ex},Val{:Bx},Val{:Ql},Val{:Ul},Val{:El},Val{:Bl}}) = getproperty(getfield(f,:fs).P,s)
 getproperty(f::FlatS02, s::Union{Val{:Ix},Val{:Il}}) = getproperty(getfield(f,:fs).I,s)
-function getindex(f::FlatS02, k::Symbol)
+function getindex(f::FlatS02, k::Symbol; kwargs...)
     @match k begin
         (:IP) => f
         (:I || :P) => getfield(f.fs,k)
-        (:Q || :U || :E || :B) => getindex(f.P,k)
-        (:Ix || :Il) => getindex(f.I,k)
-        (:Qx || :Ux || :Ql || :Ul || :Ex || :Bx || :El || :Bl) => getindex(f.P,k)
+        (:Q || :U || :E || :B) => getindex(f.P,k; kwargs...)
+        (:Ix || :Il) => getindex(f.I,k; kwargs...)
+        (:Qx || :Ux || :Ql || :Ul || :Ex || :Bx || :El || :Bl) => getindex(f.P,k; kwargs...)
         _ => throw(ArgumentError("Invalid FlatS02 index: $k"))
     end
 end

--- a/src/flat_s2.jl
+++ b/src/flat_s2.jl
@@ -90,7 +90,7 @@ function getindex(D::DiagOp{<:FlatEBFourier}, k::Symbol)
         (:QQ)        => FlatFourier{P}(@. Bl*sin2ϕ^2 + El*cos2ϕ^2)
         (:QU || :UQ) => FlatFourier{P}(@. (El - Bl) * sin2ϕ * cos2ϕ)
         (:UU)        => FlatFourier{P}(@. Bl*cos2ϕ^2 + El*sin2ϕ^2)
-        _            => getproperty(D.diag, s)
+        _            => getproperty(D.diag, k)
     end
     Diagonal(f)
 end

--- a/src/flat_s2.jl
+++ b/src/flat_s2.jl
@@ -36,7 +36,7 @@ for (F,F0,(X,Y),T) in [
     @eval begin
         @doc $doc $F
         $F($X::AbstractRank2or3Array, $Y::AbstractRank2or3Array; kwargs...) =
-            $F{Flat(Nside=size($X,2),D=size($X,3);kwargs...)}($X, $Y)
+            $F{Flat(Nside=size($X)[[2,1]],D=size($X,3);kwargs...)}($X, $Y)
         $F{P}($X::AbstractRank2or3Array, $Y::AbstractRank2or3Array) where {P} =
             $F{P}(($F0{P}($X), $F0{P}($Y)))
         $F{P,T}($X::AbstractRank2or3Array, $Y::AbstractRank2or3Array) where {P,T} =
@@ -60,27 +60,36 @@ getproperty(f::FlatEBMap,     ::Val{:Bx}) = getfield(f,:fs).B.Ix
 getproperty(f::FlatEBFourier, ::Val{:El}) = getfield(f,:fs).E.Il
 getproperty(f::FlatEBFourier, ::Val{:Bl}) = getfield(f,:fs).B.Il
 getproperty(f::FlatS2,        ::Val{:P})  = f
-function getindex(f::FlatS2, k::Symbol)
+function getindex(f::FlatS2, k::Symbol; full_plane=false)
+    maybe_unfold = (full_plane && k in [:El,:Bl,:Ql,:Ul]) ? x->unfold(x,fieldinfo(f).Ny) : identity
     B = @match k begin
-        (:P)         => Basis
-        (:E  || :B)  => f isa FlatQUMap ? EBMap : f isa FlatQUFourier ? EBFourier : Basis
-        (:Q  || :U)  => f isa FlatEBMap ? QUMap : f isa FlatEBFourier ? QUFourier : Basis
+        (:P)         => identity
+        (:E  || :B)  => @match f begin
+            _ :: FlatQUMap     => EBMap
+            _ :: FlatQUFourier => EBFourier
+            _                  => identity
+        end
+        (:Q  || :U)  => @match f begin
+            _ :: FlatEBMap     => QUMap
+            _ :: FlatEBFourier => QUFourier
+            _                  => identity
+        end
         (:Ex || :Bx) => EBMap
         (:El || :Bl) => EBFourier
         (:Qx || :Ux) => QUMap
         (:Ql || :Ul) => QUFourier
         _ => throw(ArgumentError("Invalid FlatS2 index: $k"))
     end
-    getproperty(B(f),k)
+    maybe_unfold(getproperty(B(f),k))
 end
 
-function Base.getindex(D::DiagOp{<:FlatEBFourier}, s::Symbol)
-    @unpack El, Bl = diag(D);
+function getindex(D::DiagOp{<:FlatEBFourier}, k::Symbol)
+    @unpack El, Bl = diag(D)
     @unpack sin2ϕ, cos2ϕ, P = fieldinfo(diag(D))
-    f = @match s begin
-        :QQ          => FlatFourier{P}(@. Bl*sin2ϕ^2 + El*cos2ϕ^2)
+    f = @match k begin
+        (:QQ)        => FlatFourier{P}(@. Bl*sin2ϕ^2 + El*cos2ϕ^2)
         (:QU || :UQ) => FlatFourier{P}(@. (El - Bl) * sin2ϕ * cos2ϕ)
-        :UU          => FlatFourier{P}(@. Bl*cos2ϕ^2 + El*sin2ϕ^2)
+        (:UU)        => FlatFourier{P}(@. Bl*cos2ϕ^2 + El*sin2ϕ^2)
         _            => getproperty(D.diag, s)
     end
     Diagonal(f)

--- a/src/gpu.jl
+++ b/src/gpu.jl
@@ -22,7 +22,7 @@ seed_for_storage!(::Type{<:CuArray}, seed=nothing) =
 
 ### broadcasting
 preprocess(dest::F, bc::Broadcasted) where {F<:CuFlatS0} = 
-    Broadcasted{Nothing}(cufunc(bc.f), preprocess_args(dest, bc.args), map(OneTo,_size(F)))
+    Broadcasted{Nothing}(cufunc(bc.f), preprocess_args(dest, bc.args), map(OneTo,content_size(F)))
 preprocess(dest::F, arg) where {M,F<:CuFlatS0{<:Any,<:Any,M}} = 
     adapt(M,broadcastable(F, arg))
 function copyto!(dest::F, bc::Broadcasted{Nothing}) where {F<:CuFlatS0}

--- a/src/masking.jl
+++ b/src/masking.jl
@@ -37,9 +37,9 @@ function boundarymask(Nside, pad)
 end
 
 function bleed(img, w)
-    Nx,Ny = size(img)
+    Ny,Nx = size(img)
     nearest = getfield.(@ondemand(ImageMorphology.feature_transform)(img),:I)
-    [norm(nearest[i,j] .- [i,j]) < w for i=1:Nx,j=1:Ny]
+    [norm(nearest[i,j] .- [i,j]) < w for i=1:Ny,j=1:Nx]
 end
 
 function cos_apod(img, w, smooth_distance=false)
@@ -57,7 +57,7 @@ function round_edges(img, w)
 end
 
 function sim_ptsrcs(Nside,nsources)
-    typeof(Nside) <: Tuple ? (Nx, Ny) = Nside : Nx = Ny = Nside
+    Ny, Nx = Nside .* (1,1)
     m = fill(false,Ny,Nx);
     for i=1:nsources
         m[rand(1:Ny),rand(1:Nx)] = true

--- a/src/masking.jl
+++ b/src/masking.jl
@@ -5,7 +5,7 @@ function make_mask(
     edge_rounding_deg = 1,
     apodization_deg = 1,
     ptsrc_radius_arcmin = 7, # roughly similar to Story et al. 2015
-    num_ptsrcs = typeof(Nside)<:Tuple ? round(Int, Nside[1]*Nside[2]*(θpix/60)^2 * 120/100)  : round(Int,((Nside*θpix)/60)^2 * 120/100) # SPT-like density of sources
+    num_ptsrcs = round(Int, prod(Nside .* (1,1))*(θpix/60)^2 * 120/100)  # SPT-like density of sources
     )
      
     deg2npix(x) = round(Int, x/θpix*60)
@@ -28,7 +28,7 @@ make_mask(::FlatField{<:Flat{Nside,θpix}}; kwargs...) where {Nside,θpix} = mak
 # all padding/smoothing/etc... quantities below are in units of numbers of pixels
 
 function boundarymask(Nside, pad)
-    m = typeof(Nside)<:Tuple ? fill(true,Nside[2],Nside[1]) : fill(true, Nside, Nside)
+    m = fill(true, Nside .* (1,1,))
     m[1:pad,:]          .= false
     m[:,1:pad]          .= false
     m[end-pad+1:end,:]  .= false

--- a/src/masking.jl
+++ b/src/masking.jl
@@ -43,9 +43,9 @@ function bleed(img, w)
 end
 
 function cos_apod(img, w, smooth_distance=false)
-    Nside,Nside = size(img)
+    Ny,Nx = size(img)
     nearest = getfield.(@ondemand(ImageMorphology.feature_transform)(.!img),:I)
-    distance = [norm(nearest[i,j] .- [i,j]) for i=1:Nside,j=1:Nside]
+    distance = [norm(nearest[i,j] .- [i,j]) for i=1:Ny,j=1:Nx]
     if smooth_distance!=false
         distance = @ondemand(ImageFiltering.imfilter)(distance, @ondemand(ImageFiltering.Kernel.gaussian)(smooth_distance))
     end

--- a/src/masking.jl
+++ b/src/masking.jl
@@ -5,7 +5,7 @@ function make_mask(
     edge_rounding_deg = 1,
     apodization_deg = 1,
     ptsrc_radius_arcmin = 7, # roughly similar to Story et al. 2015
-    num_ptsrcs = round(Int,((Nside*θpix)/60)^2 * 120/100) # SPT-like density of sources
+    num_ptsrcs = typeof(Nside)<:Tuple ? round(Int, Nside[1]*Nside[2]*(θpix/60)^2 * 120/100)  : round(Int,((Nside*θpix)/60)^2 * 120/100) # SPT-like density of sources
     )
      
     deg2npix(x) = round(Int, x/θpix*60)
@@ -28,7 +28,7 @@ make_mask(::FlatField{<:Flat{Nside,θpix}}; kwargs...) where {Nside,θpix} = mak
 # all padding/smoothing/etc... quantities below are in units of numbers of pixels
 
 function boundarymask(Nside, pad)
-    m = fill(true,Nside,Nside)
+    m = typeof(Nside)<:Tuple ? fill(true,Nside[2],Nside[1]) : fill(true, Nside, Nside)
     m[1:pad,:]          .= false
     m[:,1:pad]          .= false
     m[end-pad+1:end,:]  .= false
@@ -57,9 +57,10 @@ function round_edges(img, w)
 end
 
 function sim_ptsrcs(Nside,nsources)
-    m = fill(false,Nside,Nside);
+    typeof(Nside) <: Tuple ? (Nx, Ny) = Nside : Nx = Ny = Nside
+    m = fill(false,Ny,Nx);
     for i=1:nsources
-        m[rand(1:Nside),rand(1:Nside)] = true
+        m[rand(1:Ny),rand(1:Nx)] = true
     end
     m
 end

--- a/src/masking.jl
+++ b/src/masking.jl
@@ -5,9 +5,9 @@ function make_mask(
     edge_rounding_deg = 1,
     apodization_deg = 1,
     ptsrc_radius_arcmin = 7, # roughly similar to Story et al. 2015
-    num_ptsrcs = round(Int, prod(Nside .* (1,1))*(θpix/60)^2 * 120/100)  # SPT-like density of sources
-    )
-     
+    num_ptsrcs = round(Int, prod(Nside .* (1,1)) * (θpix/60)^2 * 120/100)  # SPT-like density of sources
+)
+
     deg2npix(x) = round(Int, x/θpix*60)
     arcmin2npix(x) = round(Int, x/θpix)
     

--- a/src/maximization.jl
+++ b/src/maximization.jl
@@ -116,7 +116,7 @@ function MAP_joint(
     conjgrad_kwargs = (tol=1e-1,nsteps=500),
     quasi_sample = false,
     preconditioner = :diag,
-    aggressive_gc = fieldinfo(ds.d).Nside>=1024,
+    aggressive_gc = fieldinfo(ds.d).Nx>=1024 & fieldinfo(ds.d).Ny>=1024,
     αtol = nothing,
     αmax = nothing,
 )
@@ -215,7 +215,7 @@ function MAP_marg(
     Nsims = 50,
     Nbatch = 1,
     progress::Bool = true,
-    aggressive_gc = fieldinfo(ds.d).Nside>=512
+    aggressive_gc = fieldinfo(ds.d).Nx >=512 & fieldinfo(ds.d).Ny >=512
 )
     
     ds = (@set ds.G = 1)

--- a/src/plotting.jl
+++ b/src/plotting.jl
@@ -148,7 +148,6 @@ function plot(
     fig,axs = subplots(m, n; figsize=plotsize.*[1.4*n,m], squeeze=false)
     axs = getindex.(Ref(axs), 1:m, (1:n)') # see https://github.com/JuliaPy/PyCall.jl/pull/487#issuecomment-456998345
     _plot.(fs,axs,which,title,vlim,vscale,cmap; kwargs...)
-	tight_layout(w_pad=-10)
 	
 	if return_all
 		(fig, axs, which)

--- a/src/plotting.jl
+++ b/src/plotting.jl
@@ -29,7 +29,7 @@ pretty_name(::Val{:l}) = "Fourier"
 
 function _plot(f, ax, k, title, vlim, vscale, cmap; cbar=true, units=:deg, ticklabels=true, axeslabels=false, kwargs...)
     
-	@unpack Nside, θpix = fieldinfo(f)
+	@unpack Nx, Ny, θpix = fieldinfo(f)
 	ismap = endswith(string(k), "x")
 	
 	# default values
@@ -39,7 +39,7 @@ function _plot(f, ax, k, title, vlim, vscale, cmap; cbar=true, units=:deg, tickl
 		else
 			title = pretty_name(k)
 		end
-		title *= " ($(Nside)x$(Nside) @ $(θpix)')"
+		title *= " ($(Ny)x$(Nx) @ $(θpix)')"
 	end
 	if vlim == nothing 
 		vlim = ismap ? :sym : :asym
@@ -60,7 +60,7 @@ function _plot(f, ax, k, title, vlim, vscale, cmap; cbar=true, units=:deg, tickl
 	if ismap
 		arr = Array(f[k])
 	else
-		arr = abs.(ifftshift(unfold(Array(f[k]))))
+		arr = abs.(ifftshift(unfold(Array(f[k]), Ny)))
 	end
 	if vscale == :log
 		arr[arr .== 0] .= NaN
@@ -81,7 +81,7 @@ function _plot(f, ax, k, title, vlim, vscale, cmap; cbar=true, units=:deg, tickl
 	
 	# make the plot
 	if ismap
-		extent = [-1,1,-1,1] .* θpix*Nside/Dict(:deg=>60,:arcmin=>1)[units]/2
+		extent = [-Nx,Nx,-Ny,Ny] .* θpix/Dict(:deg=>60,:arcmin=>1)[units]/2
 	else
 		extent = [-1,1,-1,1] .* fieldinfo(f).nyq
 	end

--- a/src/taylens.jl
+++ b/src/taylens.jl
@@ -19,8 +19,7 @@ end
 
 function Taylens(ϕ::FlatS0{P,T}, N) where {P,T}
 
-    g = fieldinfo(ϕ)
-    Nside = g.Nside
+    @unpack kx,ky,Nx,Ny,Δx = fieldinfo(ϕ)
     
     # total displacement
     d = ∇*ϕ
@@ -28,18 +27,18 @@ function Taylens(ϕ::FlatS0{P,T}, N) where {P,T}
 
     # nearest pixel displacement
     indexwrap(ind::Int64, uplim)  = mod(ind - 1, uplim) + 1
-    di, dj = (round.(Int,d/g.Δx) for d=(dx,dy))
-    i = indexwrap.(di .+ (1:Nside)', Nside)
-    j = indexwrap.(dj .+ (1:Nside) , Nside)
+    di, dj = (round.(Int,d/Δx) for d=(dx,dy))
+    i = indexwrap.(di .+ (1:Nx)', Nx)
+    j = indexwrap.(dj .+ (1:Ny) , Ny)
 
     # residual displacement
-    rx, ry = ((d - i.*g.Δx) for (d,i)=[(dx,di),(dy,dj)])
+    rx, ry = ((d - i.*Δx) for (d,i)=[(dx,di),(dy,dj)])
 
     # precomputation
     kα = Dict{Any,Matrix{Complex{T}}}()
     xα = Dict{Any,Matrix{T}}()
     for n in 1:N, α₁ in 0:n
-        kα[n,α₁] = im ^ n .* g.k' .^ α₁ .* g.k[1:Nside÷2+1] .^ (n - α₁)
+        kα[n,α₁] = im ^ n .* kx' .^ α₁ .* ky[1:Ny÷2+1] .^ (n - α₁)
         xα[n,α₁] = rx .^ α₁ .* ry .^ (n - α₁) ./ factorial(α₁) ./ factorial(n - α₁)
     end
 

--- a/src/util_fft.jl
+++ b/src/util_fft.jl
@@ -33,18 +33,19 @@ end
 Convert an M×N matrix (with M=N÷2+1) which is the output a real FFT to a full
 N×N one via symmetries.
 """
-unfold(Tls::AbstractArray{<:Complex,3}) = mapslices(unfold, Tls, dims=(1,2))
-unfold(Tl::AbstractMatrix{<:Complex}) = unfold(Array(Tl))
-function unfold(Tl::Matrix{<:Complex})
+unfold(Tls::AbstractArray{<:Complex,3}) = mapslices(X -> unfold(X, Ny), Tls, dims=(1,2))
+unfold(Tl::AbstractMatrix{<:Complex}, Ny) = unfold(Array(Tl), Ny)
+function unfold(Tl::Matrix{<:Complex}, Ny::Int)
     m,n = size(Tl)
-    @assert m==n÷2+1
-    m2 = iseven(n) ? 2m : 2m+1
-    Tlu = similar(Tl,n,n)
+    @assert m==Ny÷2+1
+    m2 = iseven(Ny) ? 2m : 2m+1
+    n2 = iseven(n) ?  n+2 : n+3
+    Tlu = similar(Tl,Ny,n)
     Tlu[1:m,1:n] = Tl
-    @inbounds for i=m+1:n
+    @inbounds for i=m+1:Ny
         Tlu[i,1] = Tl[m2-i, 1]'
         @simd for j=2:n
-            Tlu[i,j] = Tl[m2-i, m2-j]'
+            Tlu[i,j] = Tl[m2-i, n2-j]'
         end
     end
     Tlu

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -478,6 +478,8 @@ end
 
     for nside = [128, (128, 64), (64, 128)]
 
+      @testset  "nside = $nside" begin
+
         for T in (Float32, Float64)
             
             @testset "T :: $T" begin
@@ -514,6 +516,8 @@ end
             end
             
         end
+      end
+
     end
         
 end
@@ -527,7 +531,9 @@ end
     T = Float64
     
 
-    for nside = [128, (128, 64), (64, 128)]
+    for nside = [128, (128, 192), (192, 128)]
+
+      @testset "nside = $nside" begin
 
         for pol in (:I,:P)
             
@@ -564,7 +570,7 @@ end
             end
             
         end
-        
+      end   
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -93,7 +93,7 @@ end
     Nx = 6
     Ny = 10
     θpix = 3
-    kwargs = (Nside=(Nx, Ny), θpix=θpix)
+    kwargs = (Nside=(Ny, Nx), θpix=θpix)
     P = Flat(;kwargs...)
     Ix = rand(Ny,Nx)
     Il = rand(Ny÷2+1,Nx) + im*rand(Ny÷2+1,Nx)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -90,12 +90,13 @@ end
 
 @testset "Flat Constructors" begin
     
-    N = 2
+    Nx = 6
+    Ny = 10
     θpix = 3
-    kwargs = (Nside=N, θpix=θpix)
+    kwargs = (Nside=(Nx, Ny), θpix=θpix)
     P = Flat(;kwargs...)
-    Ix = rand(N,N)
-    Il = rand(N÷2+1,N) + im*rand(N÷2+1,N)
+    Ix = rand(Ny,Nx)
+    Il = rand(Ny÷2+1,Nx) + im*rand(Ny÷2+1,Nx)
     
     for (F,args) in [
             (FlatMap,        (Ix,)),
@@ -467,52 +468,54 @@ end;
 end
 
 ##
-
 @testset "Lensing" begin
     
     local f,ϕ
     
     Cℓ = camb().unlensed_total
-    nside = 128
     seed!(0)
     
-    for T in (Float32, Float64)
-        
-        @testset "T :: $T" begin
-                
-            ε = sqrt(eps(T))
-            Cϕ = Cℓ_to_Cov(Flat(Nside=nside), T, S0, Cℓ.ϕϕ)
-            @test (ϕ = @inferred simulate(Cϕ)) isa FlatS0
-            Lϕ = LenseFlow(ϕ)
-            
-            ## S0
-            Cf = Cℓ_to_Cov(Flat(Nside=nside), T, S0, Cℓ.TT)
-            @test (f = @inferred simulate(Cf)) isa FlatS0
-            @test (@inferred Lϕ*f) isa FlatS0
-            # adjoints
-            f,g = simulate(Cf),simulate(Cf)
-            @test f' * (Lϕ * g) ≈ (f' * Lϕ) * g
-            # gradients
-            δf, δϕ = simulate(Cf), simulate(Cϕ)
-            @test FieldTuple(gradient((f′,ϕ) -> f'*(LenseFlow(ϕ)*f′), f, ϕ))' * FieldTuple(δf,δϕ) ≈ 
-                (f'*((LenseFlow(ϕ+ε*δϕ)*(f+ε*δf))-(LenseFlow(ϕ-ε*δϕ)*(f-ε*δf)))/(2ε)) rtol=1e-2
 
-            # S2 lensing
-            Cf = Cℓ_to_Cov(Flat(Nside=nside), T, S2, Cℓ.EE, Cℓ.BB)
-            @test (f = @inferred simulate(Cf)) isa FlatS2
-            @test (@inferred Lϕ*f) isa FlatS2
-            # adjoints
-            f,g = simulate(Cf),simulate(Cf)
-            @test f' * (Lϕ * g) ≈ (f' * Lϕ) * g
-            # gradients
-            δf, δϕ = simulate(Cf), simulate(Cϕ)
-            @test FieldTuple(gradient((f′,ϕ) -> f'*(LenseFlow(ϕ)*f′), f, ϕ))' * FieldTuple(δf,δϕ) ≈ 
-                (f'*((LenseFlow(ϕ+ε*δϕ)*(f+ε*δf))-(LenseFlow(ϕ-ε*δϕ)*(f-ε*δf)))/(2ε)) rtol=1e-2
-        
+    for nside = [128, (128, 64), (64, 128)]
+
+        for T in (Float32, Float64)
+            
+            @testset "T :: $T" begin
+                    
+                ε = sqrt(eps(T))
+                Cϕ = Cℓ_to_Cov(Flat(Nside=nside), T, S0, Cℓ.ϕϕ)
+                @test (ϕ = @inferred simulate(Cϕ)) isa FlatS0
+                Lϕ = LenseFlow(ϕ)
+                
+                ## S0
+                Cf = Cℓ_to_Cov(Flat(Nside=nside), T, S0, Cℓ.TT)
+                @test (f = @inferred simulate(Cf)) isa FlatS0
+                @test (@inferred Lϕ*f) isa FlatS0
+                # adjoints
+                f,g = simulate(Cf),simulate(Cf)
+                @test f' * (Lϕ * g) ≈ (f' * Lϕ) * g
+                # gradients
+                δf, δϕ = simulate(Cf), simulate(Cϕ)
+                @test FieldTuple(gradient((f′,ϕ) -> f'*(LenseFlow(ϕ)*f′), f, ϕ))' * FieldTuple(δf,δϕ) ≈ 
+                    (f'*((LenseFlow(ϕ+ε*δϕ)*(f+ε*δf))-(LenseFlow(ϕ-ε*δϕ)*(f-ε*δf)))/(2ε)) rtol=1e-2
+
+                # S2 lensing
+                Cf = Cℓ_to_Cov(Flat(Nside=nside), T, S2, Cℓ.EE, Cℓ.BB)
+                @test (f = @inferred simulate(Cf)) isa FlatS2
+                @test (@inferred Lϕ*f) isa FlatS2
+                # adjoints
+                f,g = simulate(Cf),simulate(Cf)
+                @test f' * (Lϕ * g) ≈ (f' * Lϕ) * g
+                # gradients
+                δf, δϕ = simulate(Cf), simulate(Cϕ)
+                @test FieldTuple(gradient((f′,ϕ) -> f'*(LenseFlow(ϕ)*f′), f, ϕ))' * FieldTuple(δf,δϕ) ≈ 
+                    (f'*((LenseFlow(ϕ+ε*δϕ)*(f+ε*δf))-(LenseFlow(ϕ-ε*δϕ)*(f-ε*δf)))/(2ε)) rtol=1e-2
+            
+            end
+            
         end
-        
     end
-    
+        
 end
 
 ##
@@ -523,42 +526,46 @@ end
     L = LenseFlow{RK4Solver{7}}
     T = Float64
     
-    for pol in (:I,:P)
-        
-        @testset "pol = $pol" begin
-            
-            @unpack f,f̃,ϕ,ds,ds₀ = load_sim(
-                seed  = 0,
-                Cℓ    = Cℓ,
-                θpix  = 3,
-                Nside = 128,
-                T     = T,
-                beamFWHM = 3,
-                pol   = pol,
-                L     = L,
-                pixel_mask_kwargs = (edge_padding_deg=2,)
-                );
-            @unpack Cf,Cϕ,D = ds₀
-            f° = L(ϕ)*D*f
 
-            @test lnP(0,f,ϕ,ds) ≈ lnP(1,    f̃,  ϕ ,ds) rtol=1e-4
-            @test lnP(0,f,ϕ,ds) ≈ lnP(:mix, f°, ϕ, ds) rtol=1e-4
+    for nside = [128, (128, 64), (64, 128)]
 
-            ε = sqrt(eps(T))
-            seed!(0)
-            δf,δϕ = simulate(Cf),simulate(Cϕ)
+        for pol in (:I,:P)
             
-            @test FieldTuple(gradient((f,ϕ)->lnP(0,f,ϕ,ds),f,ϕ))'*FieldTuple(δf,δϕ) ≈ 
-                (lnP(0,f+ε*δf,ϕ+ε*δϕ,ds)-lnP(0,f-ε*δf,ϕ-ε*δϕ,ds))/(2ε)  rtol=3e-2
-            @test FieldTuple(gradient((f̃,ϕ)->lnP(1,f̃,ϕ,ds),f̃,ϕ))'*FieldTuple(δf,δϕ) ≈ 
-                (lnP(1,f̃+ε*δf,ϕ+ε*δϕ,ds)-lnP(1,f̃-ε*δf,ϕ-ε*δϕ,ds))/(2ε)  rtol=3e-2
-            @test FieldTuple(gradient((f°,ϕ)->lnP(:mix,f°,ϕ,ds),f°,ϕ))'*FieldTuple(δf,δϕ) ≈ 
-                (lnP(:mix,f°+ε*δf,ϕ+ε*δϕ,ds)-lnP(:mix,f°-ε*δf,ϕ-ε*δϕ,ds))/(2ε)  rtol=3e-2
+            @testset "pol = $pol" begin
+                
+                @unpack f,f̃,ϕ,ds,ds₀ = load_sim(
+                    seed  = 0,
+                    Cℓ    = Cℓ,
+                    θpix  = 3,
+                    Nside = nside,
+                    T     = T,
+                    beamFWHM = 3,
+                    pol   = pol,
+                    L     = L,
+                    pixel_mask_kwargs = (edge_padding_deg=2,)
+                    );
+                @unpack Cf,Cϕ,D = ds₀
+                f° = L(ϕ)*D*f
+
+                @test lnP(0,f,ϕ,ds) ≈ lnP(1,    f̃,  ϕ ,ds) rtol=1e-4
+                @test lnP(0,f,ϕ,ds) ≈ lnP(:mix, f°, ϕ, ds) rtol=1e-4
+
+                ε = sqrt(eps(T))
+                seed!(0)
+                δf,δϕ = simulate(Cf),simulate(Cϕ)
+                
+                @test FieldTuple(gradient((f,ϕ)->lnP(0,f,ϕ,ds),f,ϕ))'*FieldTuple(δf,δϕ) ≈ 
+                    (lnP(0,f+ε*δf,ϕ+ε*δϕ,ds)-lnP(0,f-ε*δf,ϕ-ε*δϕ,ds))/(2ε)  rtol=3e-2
+                @test FieldTuple(gradient((f̃,ϕ)->lnP(1,f̃,ϕ,ds),f̃,ϕ))'*FieldTuple(δf,δϕ) ≈ 
+                    (lnP(1,f̃+ε*δf,ϕ+ε*δϕ,ds)-lnP(1,f̃-ε*δf,ϕ-ε*δϕ,ds))/(2ε)  rtol=3e-2
+                @test FieldTuple(gradient((f°,ϕ)->lnP(:mix,f°,ϕ,ds),f°,ϕ))'*FieldTuple(δf,δϕ) ≈ 
+                    (lnP(:mix,f°+ε*δf,ϕ+ε*δϕ,ds)-lnP(:mix,f°-ε*δf,ϕ-ε*δϕ,ds))/(2ε)  rtol=3e-2
+                
+            end
             
         end
         
     end
-    
 end
 
 ##


### PR DESCRIPTION
This PR addresses issue #15. In this first pass, I have run all the cases in `CMBLensing.jl/docs/src/01-03` and the code produced sensible results when Nside=(Nx,Ny). 

New: 
- Nside can now be a Number or a Tuple. 
-- If Nside <: Number, then the previous square-map behavior is preserved.
-- If Nside <: Tuple, it expects Nside = (Nx, Ny).

Next steps:
- Add documentation about Nside
- Adjust the aspect ratio of figsize when plotting non-square map.  
- Test GPU cases

@marius311: There are definitely places where I think someone who is more familiar with Julia/CMBLensing.jl can streamline. There are also places I think should work but probably didn't get tested when running the examples above. 
