### PR TITLE
Allow scalars and Arrays in FieldTuples

### DIFF
--- a/src/generic.jl
+++ b/src/generic.jl
@@ -123,7 +123,7 @@ HarmonicBasis(::Basis2Prod{𝐄𝐁,         <:S0Basis}) = EBFourier
 (::Type{B})(dst::AbstractArray{<:Field}, src::AbstractArray{<:Field}) where {B<:Basis} = B.(dst,src)
 
 # The abstract `Basis` type means "any basis", hence this conversion rule:
-Basis(f::Field) = f
+Basis(f) = f
 
 
 # used in make_field_aliases below

--- a/src/generic.jl
+++ b/src/generic.jl
@@ -224,7 +224,7 @@ unknown_rule_error(::typeof(promote_basis_strict_rule), ::B₁, ::B₂) where {B
 basis(f::F) where {F<:Field} = basis(F)
 basis(::Type{<:Field{B}}) where {B<:Basis} = B
 basis(::Type{<:Field}) = Basis
-basis(::AbstractVector) = Basis
+basis(::Union{Number,AbstractVector}) = Basis # allows them to be in FieldTuple
 
 
 ### printing


### PR DESCRIPTION
Eg:

```julia

using CMBLensing, LinearAlgebra

f = FlatMap(rand(10,10))
ft = FieldTuple(;f, AL=1., r=0, Aϕ=[1,2])

ft2 = ft .+ ft # broadcasting works
ft3 = Diagonal(ft2) * ft # diagonal operators
ft3'ft3 # inner prod
(;f, AL) = ft2 # unpacking components

gradient(ft -> norm(Diagonal(ft)*ft), ft)[1] # gradients work
```